### PR TITLE
feat(backend): structured JSON logging via log/slog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Clean Architecture: `cmd/api` (wiring) → `internal/domain` (entities/repos/eve
 - **sqlc workflow:** edit `sql/queries/*.sql`, run `sqlc generate`, implement in `postgres/`. Never edit `internal/infrastructure/db/sqlc/` manually.
 - **Events:** `EventDispatcher` routes by `event_type` string; unknown types silently ignored (forward compat).
 - **Testing:** real Postgres via testcontainers (`testhelpers.SetupTestDB(t)`), no DB mocking; Docker must be running.
+- **Logging:** structured JSON via `log/slog` (`internal/infrastructure/logging`), stdout, level via `LOG_LEVEL`. Logger is passed by constructor DI, never a global — every service/controller that logs takes a `*slog.Logger` param. No `log.Printf`/`fmt.Print*`.
 
 ## Architecture notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,9 @@ Clean Architecture: `cmd/api` (wiring) → `internal/domain` (entities/repos/eve
 - **Validated types:** repos only accept validated domain types — invalid state unrepresentable at compile time.
 - **Soft deletes:** `todo_lists`/`todos` have `deleted_at`; queries filter `WHERE deleted_at IS NULL`.
 - **sqlc workflow:** edit `sql/queries/*.sql`, run `sqlc generate`, implement in `postgres/`. Never edit `internal/infrastructure/db/sqlc/` manually.
-- **Events:** `EventDispatcher` routes by `event_type` string; unknown types silently ignored (forward compat).
+- **Events:** `EventDispatcher` routes by `event_type` string; unknown types are a no-op, not an error (forward compat), but logged at `warn` since it signals client/server version skew.
 - **Testing:** real Postgres via testcontainers (`testhelpers.SetupTestDB(t)`), no DB mocking; Docker must be running.
-- **Logging:** structured JSON via `log/slog` (`internal/infrastructure/logging`), stdout, level via `LOG_LEVEL`. Logger is passed by constructor DI, never a global — every service/controller that logs takes a `*slog.Logger` param. No `log.Printf`/`fmt.Print*`.
+- **Logging:** structured JSON via `log/slog` (`internal/infrastructure/logging`), stdout, level via `LOG_LEVEL`. Logger is passed by constructor DI — every service/controller that logs takes a `*slog.Logger` param; no `log.Printf`/`fmt.Print*`. `slog.SetDefault` is set once in `main` purely to catch stray stdlib `log` output from dependencies, not as a substitute for DI.
 
 ## Architecture notes
 

--- a/backend/.env
+++ b/backend/.env
@@ -1,3 +1,4 @@
 DATABASE_URL="host=localhost user=postgres password=postgres dbname=todos port=5432 sslmode=disable"
 KEYCLOAK_ISSUER="https://sso.ops.light-dev-solutions.de/realms/user-apps"
 KEYCLOAK_CLIENT_ID="shopping-list"
+LOG_LEVEL="debug"

--- a/backend/README.md
+++ b/backend/README.md
@@ -59,6 +59,23 @@ fetches lists already known and sync-enabled locally. See
 | GET | `/api/v1/sync/events` | Pull: one page of a list's event history since a given seq |
 | GET | `/api/v1/sync/ws` | WebSocket; pushes per-event `ack`s and, to clients subscribed to a list (`{"type":"subscribe","list_ids":[...]}`), a `{"type":"event"}` notification when that list gets a new event |
 
+## Logging
+
+The API logs structured JSON to stdout (via `log/slog`), one line per event
+or request:
+
+```json
+{"time":"2026-08-02T10:00:00Z","level":"INFO","msg":"request","service":"shopping-list-api","version":"dev","request_id":"3f9c...","method":"GET","uri":"/api/v1/todo-lists","status":200,"latency":1200000}
+```
+
+- `LOG_LEVEL` — `debug|info|warn|error` (default `info`). `debug` also adds
+  source file/line and per-connection WebSocket detail.
+- `LOG_FORMAT` — `json` (default) or `text` for a more readable local format.
+- Every request gets a `request_id` (from `X-Request-Id` or generated), set
+  on the response header and threaded through the request's logger so
+  access-log lines, handler errors, and panics for the same request all
+  carry the same id.
+
 ## Updating the dev database schema
 
 Migrations are embedded into the binary (`migrations/migrations.go`) and

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"log/slog"
+	"net/http"
 	"os"
 
 	"github.com/labstack/echo/v4"
+	echomw "github.com/labstack/echo/v4/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/services"
 	postgres2 "github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/db/postgres"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/logging"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/realtime"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest"
@@ -15,6 +19,16 @@ import (
 )
 
 func main() {
+	logger := logging.New(os.Stdout)
+	slog.SetDefault(logger)
+
+	if err := run(logger); err != nil {
+		logger.Error("fatal", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(logger *slog.Logger) error {
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
 		dsn = "host=localhost user=postgres password=postgres dbname=todos port=5432 sslmode=disable"
@@ -24,13 +38,13 @@ func main() {
 	ctx := context.Background()
 	pool, err := postgres2.NewConnection(ctx, dsn)
 	if err != nil {
-		log.Fatalf("Failed to connect to database: %v", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer pool.Close()
 
 	// Apply pending schema migrations before anything touches the DB.
-	if err := postgres2.Migrate(ctx, pool, appmigrations.FS); err != nil {
-		log.Fatalf("Failed to apply migrations: %v", err)
+	if err := postgres2.Migrate(ctx, logger, pool, appmigrations.FS); err != nil {
+		return fmt.Errorf("failed to apply migrations: %w", err)
 	}
 
 	queries := postgres2.NewQueries(pool)
@@ -41,29 +55,81 @@ func main() {
 	toDoListService := services.NewToDoListService(toDoListRepo)
 
 	eventDispatcher := services.NewEventDispatcher(
+		logger,
 		services.NewCreateToDoListEventHandler(toDoListService),
 		services.NewUpdateToDoListEventHandler(toDoListService),
 		services.NewDeleteToDoListEventHandler(toDoListService),
 	)
 
-	hub := realtime.NewHub()
-	eventIngestor := services.NewEventIngestor(eventRepo, eventDispatcher, hub)
+	hub := realtime.NewHub(logger)
+	eventIngestor := services.NewEventIngestor(logger, eventRepo, eventDispatcher, hub)
 	eventIngestor.Start(ctx)
 	defer eventIngestor.Stop()
 
-	authMW, err := middleware.NewKeycloakAuth(ctx)
+	authMW, err := middleware.NewKeycloakAuth(ctx, logger)
 	if err != nil {
-		log.Fatalf("auth: %v", err)
+		return fmt.Errorf("auth: %w", err)
 	}
 
 	e := echo.New()
-	rest.NewToDoListController(e, toDoListService)
-	rest.NewEventController(e, eventIngestor, authMW)
-	rest.NewSyncWebSocketController(e, hub, authMW)
-	rest.NewSyncStateController(e, eventRepo, authMW)
-	rest.NewSyncPullController(e, eventRepo, authMW)
+	e.HideBanner = true
+	e.HidePort = true
+	e.HTTPErrorHandler = httpErrorHandler(logger, e.DefaultHTTPErrorHandler)
 
+	e.Use(echomw.RequestID())
+	e.Use(echomw.RecoverWithConfig(echomw.RecoverConfig{
+		LogErrorFunc: func(c echo.Context, err error, stack []byte) error {
+			middleware.RequestScopedLogger(logger, c).Error("panic recovered", "error", err, "stack", string(stack))
+			return err
+		},
+	}))
+	e.Use(middleware.RequestLogger(logger))
+	e.Use(middleware.ContextLogger(logger))
+
+	rest.NewToDoListController(e, logger, toDoListService)
+	rest.NewEventController(e, logger, eventIngestor, authMW)
+	rest.NewSyncWebSocketController(e, hub, authMW)
+	rest.NewSyncStateController(e, logger, eventRepo, authMW)
+	rest.NewSyncPullController(e, logger, eventRepo, authMW)
+
+	logger.Info("server starting", "port", port)
 	if err := e.Start(port); err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+		return fmt.Errorf("failed to start server: %w", err)
+	}
+	return nil
+}
+
+// httpErrorHandler logs errors that never went through a controller's own
+// JSON response (e.g. a failed websocket upgrade, or Echo's own 404/405) -
+// level by status, same convention as the access log - then delegates to
+// fallback for the actual response.
+//
+// middleware.RequestLogger's HandleError:true already forwards handler
+// errors here via c.Error before they bubble back up to Echo's own
+// ServeHTTP, which then calls this same handler a second time with the
+// identical error (see echo's RequestLoggerWithConfig doc comment) - so,
+// same as Echo's own DefaultHTTPErrorHandler, this is a no-op once the
+// response is already committed, to avoid logging (and trying to write)
+// the same error twice.
+func httpErrorHandler(logger *slog.Logger, fallback echo.HTTPErrorHandler) echo.HTTPErrorHandler {
+	return func(err error, c echo.Context) {
+		if c.Response().Committed {
+			return
+		}
+
+		status := http.StatusInternalServerError
+		if he, ok := err.(*echo.HTTPError); ok {
+			status = he.Code
+		}
+
+		l := middleware.RequestScopedLogger(logger, c)
+		switch {
+		case status >= 500:
+			l.Error("http error", "status", status, "error", err)
+		case status >= 400:
+			l.Warn("http error", "status", status, "error", err)
+		}
+
+		fallback(err, c)
 	}
 }

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -20,6 +20,11 @@ import (
 
 func main() {
 	logger := logging.New(os.Stdout)
+	// Every component here gets logger via DI, not slog.Default() - this
+	// only exists so a stray stdlib log.Print in a dependency we don't
+	// control (or a future log.Println someone reaches for instead of the
+	// injected logger) still lands in the same JSON stream instead of
+	// unstructured plaintext on stderr.
 	slog.SetDefault(logger)
 
 	if err := run(logger); err != nil {

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       # locally). Required - the API refuses to start without it.
       KEYCLOAK_ISSUER: "https://sso.ops.light-dev-solutions.de/realms/user-apps"
       KEYCLOAK_CLIENT_ID: "shopping-list"
+      LOG_LEVEL: "info"
     depends_on:
       postgres:
         condition: service_healthy

--- a/backend/internal/application/services/event-dispatcher.go
+++ b/backend/internal/application/services/event-dispatcher.go
@@ -3,28 +3,32 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
 )
 
 type EventDispatcher struct {
+	logger   *slog.Logger
 	handlers map[string]interfaces.EventHandler
 }
 
-func NewEventDispatcher(handlers ...interfaces.EventHandler) *EventDispatcher {
+func NewEventDispatcher(logger *slog.Logger, handlers ...interfaces.EventHandler) *EventDispatcher {
 	m := make(map[string]interfaces.EventHandler, len(handlers))
 	for _, h := range handlers {
 		m[h.EventType()] = h
 	}
-	return &EventDispatcher{handlers: m}
+	return &EventDispatcher{logger: logger, handlers: m}
 }
 
 // Dispatch routes a single event to its handler. Unknown event types are silently
-// ignored so the backend stays forward-compatible with events from newer clients.
+// ignored so the backend stays forward-compatible with events from newer clients -
+// but logged, since it also signals client/server version skew worth knowing about.
 func (d *EventDispatcher) Dispatch(ctx context.Context, eventType string, aggregateID uuid.UUID, payload json.RawMessage) error {
 	handler, ok := d.handlers[eventType]
 	if !ok {
+		d.logger.Warn("unknown event type", "event_type", eventType, "aggregate_id", aggregateID)
 		return nil
 	}
 	return handler.Handle(ctx, aggregateID, payload)

--- a/backend/internal/application/services/event-ingestor.go
+++ b/backend/internal/application/services/event-ingestor.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sync"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
@@ -38,6 +38,7 @@ type realtimePublisher interface {
 // simply queued behind the first, which will have finished (successfully
 // or not) by the time the worker gets to it.
 type EventIngestor struct {
+	logger     *slog.Logger
 	eventRepo  repositories.EventRepository
 	dispatcher *EventDispatcher
 	publisher  realtimePublisher
@@ -47,11 +48,13 @@ type EventIngestor struct {
 }
 
 func NewEventIngestor(
+	logger *slog.Logger,
 	eventRepo repositories.EventRepository,
 	dispatcher *EventDispatcher,
 	publisher realtimePublisher,
 ) *EventIngestor {
 	return &EventIngestor{
+		logger:     logger,
 		eventRepo:  eventRepo,
 		dispatcher: dispatcher,
 		publisher:  publisher,
@@ -106,7 +109,7 @@ func (ing *EventIngestor) Stop() {
 func (ing *EventIngestor) sweepUnprocessed(ctx context.Context) {
 	unprocessed, err := ing.eventRepo.FindUnprocessed(ctx)
 	if err != nil {
-		log.Printf("event-ingestor: failed to sweep unprocessed events: %v", err)
+		ing.logger.Error("failed to sweep unprocessed events", "error", err)
 		return
 	}
 	for _, event := range unprocessed {
@@ -117,7 +120,7 @@ func (ing *EventIngestor) sweepUnprocessed(ctx context.Context) {
 func (ing *EventIngestor) process(ctx context.Context, event *repositories.StoredEvent) {
 	alreadyProcessed, seq, _, err := ing.eventRepo.Insert(ctx, event)
 	if err != nil {
-		log.Printf("event-ingestor: failed to insert event %s: %v", event.EventID, err)
+		ing.logger.Error("failed to insert event", "event_id", event.EventID, "error", err)
 		return
 	}
 	if alreadyProcessed {
@@ -142,15 +145,15 @@ func (ing *EventIngestor) dispatchAndAck(ctx context.Context, event *repositorie
 	// received", so it's still marked processed and acked. Only handled
 	// types that error should stay unprocessed for a retry.
 	if err := ing.dispatcher.Dispatch(ctx, event.EventType, event.AggregateID, event.Payload); err != nil {
-		log.Printf(
-			"event-ingestor: failed to dispatch event %s (%s): %v",
-			event.EventID, event.EventType, err,
+		ing.logger.Error(
+			"failed to dispatch event",
+			"event_id", event.EventID, "event_type", event.EventType, "error", err,
 		)
 		return
 	}
 	seq, listID, err := ing.eventRepo.MarkProcessed(ctx, event.EventID)
 	if err != nil {
-		log.Printf("event-ingestor: failed to mark event %s processed: %v", event.EventID, err)
+		ing.logger.Error("failed to mark event processed", "event_id", event.EventID, "error", err)
 		return
 	}
 	ing.publisher.PublishAck(event.ClientID, event.EventID, seq)

--- a/backend/internal/application/services/event-ingestor_test.go
+++ b/backend/internal/application/services/event-ingestor_test.go
@@ -21,6 +21,34 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
+// syncBuffer wraps bytes.Buffer with a mutex so it's safe to write from the
+// ingestor's worker goroutine while a test concurrently polls it (e.g. via
+// require.Eventually, which runs its check function in its own goroutine) -
+// slog's handler only synchronizes its own writes against each other, not
+// against unrelated reads of the same io.Writer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Len()
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.buf.Bytes()...)
+}
+
 // fakeEventRepo is a hand-rolled in-memory double - this backend has no
 // mocking library, and testcontainers (used elsewhere) would be overkill
 // for testing the ingestor's own orchestration logic, which is what these
@@ -365,7 +393,7 @@ func TestEventIngestor_DispatchFailure_NoAckAndNotMarkedProcessed(t *testing.T) 
 // must produce a structured error record carrying the event id, so an
 // on-call engineer can find it without a debugger.
 func TestEventIngestor_DispatchFailure_LogsWithEventContext(t *testing.T) {
-	var buf bytes.Buffer
+	var buf syncBuffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
 	repo := newFakeEventRepo()

--- a/backend/internal/application/services/event-ingestor_test.go
+++ b/backend/internal/application/services/event-ingestor_test.go
@@ -1,9 +1,11 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +16,10 @@ import (
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
 )
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 // fakeEventRepo is a hand-rolled in-memory double - this backend has no
 // mocking library, and testcontainers (used elsewhere) would be overkill
@@ -208,9 +214,9 @@ func makeIngestorTestEvent(eventType string) *repositories.StoredEvent {
 func TestEventIngestor_ProcessesAndAcksAFreshEvent(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -231,9 +237,9 @@ func TestEventIngestor_ProcessesAndAcksAFreshEvent(t *testing.T) {
 func TestEventIngestor_PublishesAListEventWithTheAssignedSeqAfterProcessing(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -255,9 +261,9 @@ func TestEventIngestor_PublishesAListEventWithTheAssignedSeqAfterProcessing(t *t
 func TestEventIngestor_DoesNotPublishAListEventWhenTheEventHasNoListID(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -280,9 +286,9 @@ func TestEventIngestor_DoesNotPublishAListEventWhenTheEventHasNoListID(t *testin
 func TestEventIngestor_DuplicateEventID_DoesNotPublishASecondListEvent(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -308,9 +314,9 @@ func TestEventIngestor_DuplicateEventID_DoesNotPublishASecondListEvent(t *testin
 func TestEventIngestor_DuplicateEventID_AcksWithoutRedispatching(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -334,9 +340,9 @@ func TestEventIngestor_DuplicateEventID_AcksWithoutRedispatching(t *testing.T) {
 func TestEventIngestor_DispatchFailure_NoAckAndNotMarkedProcessed(t *testing.T) {
 	repo := newFakeEventRepo()
 	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("todo list not found")}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -354,13 +360,45 @@ func TestEventIngestor_DispatchFailure_NoAckAndNotMarkedProcessed(t *testing.T) 
 	assert.False(t, repo.isProcessed(event.EventID))
 }
 
+// TestEventIngestor_DispatchFailure_LogsWithEventContext asserts the
+// injected logger is actually used, not just accepted - a failed dispatch
+// must produce a structured error record carrying the event id, so an
+// on-call engineer can find it without a debugger.
+func TestEventIngestor_DispatchFailure_LogsWithEventContext(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	repo := newFakeEventRepo()
+	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("todo list not found")}
+	dispatcher := NewEventDispatcher(logger, handler)
+	ack := &fakeAckPublisher{}
+	ingestor := NewEventIngestor(logger, repo, dispatcher, ack)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingestor.Start(ctx)
+	defer ingestor.Stop()
+
+	event := makeIngestorTestEvent("todo_list.updated")
+	require.NoError(t, ingestor.Enqueue(ctx, event))
+	require.Eventually(t, func() bool { return handler.callCount() == 1 }, time.Second, time.Millisecond)
+	// Give the (async) log write a moment to land.
+	require.Eventually(t, func() bool { return buf.Len() > 0 }, time.Second, time.Millisecond)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, "ERROR", decoded["level"])
+	assert.Equal(t, event.EventID.String(), decoded["event_id"])
+	assert.Contains(t, decoded["error"], "todo list not found")
+}
+
 func TestEventIngestor_UnknownEventType_StillAckedForwardCompatibly(t *testing.T) {
 	repo := newFakeEventRepo()
 	// No handler registered for "ingredient.created" - EventDispatcher
 	// silently no-ops per its own forward-compatibility contract.
-	dispatcher := NewEventDispatcher()
+	dispatcher := NewEventDispatcher(testLogger())
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -380,9 +418,9 @@ func TestEventIngestor_Start_SweepsUnprocessedEventsFromPreviousRun(t *testing.T
 	repo.unprocessed = []*repositories.StoredEvent{stuck}
 
 	handler := &fakeHandler{eventType: "todo_list.created"}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -407,9 +445,9 @@ func TestEventIngestor_ProcessesEventsForTheSameAggregateInEnqueueOrder(t *testi
 			order = append(order, string(payload))
 		},
 	}
-	dispatcher := NewEventDispatcher(handler)
+	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -449,9 +487,9 @@ func (h *orderTrackingHandler) Handle(ctx context.Context, aggregateID uuid.UUID
 
 func TestEventIngestor_Stop_ReturnsWithoutHanging(t *testing.T) {
 	repo := newFakeEventRepo()
-	dispatcher := NewEventDispatcher()
+	dispatcher := NewEventDispatcher(testLogger())
 	ack := &fakeAckPublisher{}
-	ingestor := NewEventIngestor(repo, dispatcher, ack)
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/backend/internal/infrastructure/db/postgres/migrate.go
+++ b/backend/internal/infrastructure/db/postgres/migrate.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"sort"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -33,7 +33,7 @@ const advisoryLockKey = int64(-8876109641015196089)
 // schema_migrations, or it is rolled back entirely and not recorded.
 // Already-applied versions are skipped, so Migrate is safe to run on every
 // startup.
-func Migrate(ctx context.Context, pool *pgxpool.Pool, sqlFS fs.FS) error {
+func Migrate(ctx context.Context, logger *slog.Logger, pool *pgxpool.Pool, sqlFS fs.FS) error {
 	// One dedicated connection for the whole run so the advisory lock and
 	// the migrations live on the same session.
 	conn, err := pool.Acquire(ctx)
@@ -74,11 +74,7 @@ func Migrate(ctx context.Context, pool *pgxpool.Pool, sqlFS fs.FS) error {
 		appliedCount++
 	}
 
-	if appliedCount == 0 {
-		log.Printf("migrate: schema up to date (%d migrations applied)", len(names))
-	} else {
-		log.Printf("migrate: applied %d migration(s)", appliedCount)
-	}
+	logger.Info("migrations applied", "applied_count", appliedCount, "total_count", len(names))
 	return nil
 }
 

--- a/backend/internal/infrastructure/db/postgres/migrate_test.go
+++ b/backend/internal/infrastructure/db/postgres/migrate_test.go
@@ -2,6 +2,7 @@ package postgres_test
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -38,7 +39,7 @@ func TestMigrateAppliesPendingAndIsIdempotent(t *testing.T) {
 	defer pool.Close()
 
 	// A fresh, schema-less DB: Migrate should apply every .up.sql migration.
-	err = db.Migrate(ctx, pool, appmigrations.FS)
+	err = db.Migrate(ctx, slog.New(slog.DiscardHandler), pool, appmigrations.FS)
 	require.NoError(t, err, "first Migrate run should succeed")
 
 	var versionCount int
@@ -54,6 +55,6 @@ func TestMigrateAppliesPendingAndIsIdempotent(t *testing.T) {
 	require.True(t, hasListID, "expected events.list_id after migrations")
 
 	// A second run must be a no-op, not an error or a duplicate apply.
-	err = db.Migrate(ctx, pool, appmigrations.FS)
+	err = db.Migrate(ctx, slog.New(slog.DiscardHandler), pool, appmigrations.FS)
 	require.NoError(t, err, "second (idempotent) Migrate run should succeed")
 }

--- a/backend/internal/infrastructure/logging/context.go
+++ b/backend/internal/infrastructure/logging/context.go
@@ -1,0 +1,22 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+)
+
+type contextKey struct{}
+
+// NewContext returns a copy of ctx carrying l as the request-scoped logger.
+func NewContext(ctx context.Context, l *slog.Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, l)
+}
+
+// FromContext returns the logger stashed by NewContext, or slog.Default()
+// if none was set - callers never need a nil check.
+func FromContext(ctx context.Context) *slog.Logger {
+	if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok {
+		return l
+	}
+	return slog.Default()
+}

--- a/backend/internal/infrastructure/logging/logger.go
+++ b/backend/internal/infrastructure/logging/logger.go
@@ -1,0 +1,71 @@
+// Package logging builds the application's single structured logger and
+// carries it through request contexts. All env access for logging
+// configuration (LOG_LEVEL, LOG_FORMAT) lives here, not scattered across
+// the app.
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+const serviceName = "shopping-list-api"
+
+// New builds the application's logger, writing structured records to w.
+// LOG_LEVEL (debug|info|warn|error, default info) controls verbosity;
+// LOG_FORMAT (json|text, default json) selects the encoding - text is only
+// meant as a local convenience (e.g. under `air`). Every record carries a
+// service and version attribute, so logs are self-describing once shipped
+// off-host.
+func New(w io.Writer) *slog.Logger {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+	opts := &slog.HandlerOptions{
+		Level:     level,
+		AddSource: level == slog.LevelDebug,
+	}
+
+	var handler slog.Handler
+	if strings.EqualFold(os.Getenv("LOG_FORMAT"), "text") {
+		handler = slog.NewTextHandler(w, opts)
+	} else {
+		handler = slog.NewJSONHandler(w, opts)
+	}
+
+	return slog.New(handler).With(
+		"service", serviceName,
+		"version", buildVersion(),
+	)
+}
+
+func parseLevel(raw string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	case "", "info":
+		return slog.LevelInfo
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// buildVersion reads the VCS revision embedded by the Go toolchain, falling
+// back to "dev" for builds without that info (e.g. `go run`).
+func buildVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev"
+	}
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			return setting.Value
+		}
+	}
+	return "dev"
+}

--- a/backend/internal/infrastructure/logging/logger_test.go
+++ b/backend/internal/infrastructure/logging/logger_test.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := map[string]slog.Level{
+		"":         slog.LevelInfo,
+		"info":     slog.LevelInfo,
+		"INFO":     slog.LevelInfo,
+		"debug":    slog.LevelDebug,
+		"warn":     slog.LevelWarn,
+		"warning":  slog.LevelWarn,
+		"error":    slog.LevelError,
+		"nonsense": slog.LevelInfo,
+	}
+	for raw, want := range tests {
+		assert.Equal(t, want, parseLevel(raw), "input %q", raw)
+	}
+}
+
+func TestNew_EmitsStructuredJSONWithBaseAttributes(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_FORMAT", "json")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Info("hello", "foo", "bar")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, "hello", decoded["msg"])
+	assert.Equal(t, "INFO", decoded["level"])
+	assert.Equal(t, serviceName, decoded["service"])
+	assert.Equal(t, "bar", decoded["foo"])
+	assert.NotEmpty(t, decoded["version"])
+}
+
+func TestNew_RespectsLevelFilter(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "warn")
+
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.Info("should be filtered out")
+	assert.Empty(t, buf.String())
+
+	logger.Warn("should appear")
+	assert.NotEmpty(t, buf.String())
+}
+
+func TestContext_RoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	ctx := NewContext(context.Background(), logger)
+	assert.Same(t, logger, FromContext(ctx))
+}
+
+func TestContext_FallsBackToDefault(t *testing.T) {
+	assert.Same(t, slog.Default(), FromContext(context.Background()))
+}

--- a/backend/internal/infrastructure/realtime/hub.go
+++ b/backend/internal/infrastructure/realtime/hub.go
@@ -1,7 +1,7 @@
 package realtime
 
 import (
-	"log"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -49,6 +49,7 @@ func (c *connection) writeJSON(v any) error {
 // alone would delete the new connection instead of the dead one. List
 // subscriptions follow the same by-pointer discipline for the same reason.
 type Hub struct {
+	logger  *slog.Logger
 	mu      sync.RWMutex
 	clients map[string]map[*connection]struct{}
 	// subscriptions maps list_id -> the connections subscribed to it.
@@ -59,8 +60,9 @@ type Hub struct {
 	subscribedLists map[*connection]map[uuid.UUID]struct{}
 }
 
-func NewHub() *Hub {
+func NewHub(logger *slog.Logger) *Hub {
 	return &Hub{
+		logger:          logger,
 		clients:         make(map[string]map[*connection]struct{}),
 		subscriptions:   make(map[uuid.UUID]map[*connection]struct{}),
 		subscribedLists: make(map[*connection]map[uuid.UUID]struct{}),
@@ -151,7 +153,9 @@ func (h *Hub) PublishAck(clientID string, eventID uuid.UUID, seq int64) {
 	msg := map[string]any{"type": "ack", "event_id": eventID.String(), "seq": seq}
 	for _, conn := range h.connectionsFor(clientID) {
 		if err := conn.writeJSON(msg); err != nil {
-			log.Printf("realtime: failed to send ack to client %s: %v", clientID, err)
+			// Warn, not Error: a client that disconnected mid-send is
+			// expected, not a server fault.
+			h.logger.Warn("failed to send ack", "client_id", clientID, "event_id", eventID, "error", err)
 		}
 	}
 }
@@ -164,7 +168,7 @@ func (h *Hub) PublishListEvent(listID uuid.UUID, seq int64) {
 	msg := map[string]any{"type": "event", "list_id": listID.String(), "seq": seq}
 	for _, conn := range h.subscribersFor(listID) {
 		if err := conn.writeJSON(msg); err != nil {
-			log.Printf("realtime: failed to send list event for %s: %v", listID, err)
+			h.logger.Warn("failed to send list event", "list_id", listID, "seq", seq, "error", err)
 		}
 	}
 }
@@ -176,15 +180,20 @@ func (h *Hub) PublishListEvent(listID uuid.UUID, seq int64) {
 func (h *Hub) Serve(clientID string, ws *websocket.Conn) {
 	conn := newConnection(ws)
 	h.register(clientID, conn)
+	h.logger.Debug("connection registered", "client_id", clientID)
 	defer func() {
 		h.unregister(clientID, conn)
 		_ = ws.Close()
+		h.logger.Debug("connection closed", "client_id", clientID)
 	}()
 
 	_ = ws.SetReadDeadline(time.Now().Add(readDeadline))
 	for {
 		var msg map[string]any
 		if err := ws.ReadJSON(&msg); err != nil {
+			// Debug, not Warn/Error: a client going away (app backgrounded,
+			// network drop) is the normal way this loop ends.
+			h.logger.Debug("read loop ended", "client_id", clientID, "error", err)
 			return
 		}
 		_ = ws.SetReadDeadline(time.Now().Add(readDeadline))
@@ -192,10 +201,13 @@ func (h *Hub) Serve(clientID string, ws *websocket.Conn) {
 		switch msg["type"] {
 		case "ping":
 			if err := conn.writeJSON(map[string]string{"type": "pong"}); err != nil {
+				h.logger.Debug("failed to send pong", "client_id", clientID, "error", err)
 				return
 			}
 		case "subscribe":
-			h.subscribe(conn, parseListIDs(msg["list_ids"]))
+			listIDs := parseListIDs(msg["list_ids"])
+			h.subscribe(conn, listIDs)
+			h.logger.Debug("subscribed", "client_id", clientID, "list_count", len(listIDs))
 		}
 	}
 }

--- a/backend/internal/infrastructure/realtime/hub_test.go
+++ b/backend/internal/infrastructure/realtime/hub_test.go
@@ -1,6 +1,7 @@
 package realtime
 
 import (
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 // startTestServer wires the hub behind a plain net/http (not Echo) upgrade
 // handler - the hub's contract doesn't depend on Echo, and this keeps the
@@ -43,7 +48,7 @@ func dial(t *testing.T, server *httptest.Server, clientID string) *websocket.Con
 }
 
 func TestHub_PublishAck_DeliversToConnectedClient(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	server := startTestServer(t, hub)
 	conn := dial(t, server, "client-1")
 
@@ -63,7 +68,7 @@ func TestHub_PublishAck_DeliversToConnectedClient(t *testing.T) {
 }
 
 func TestHub_PublishAck_NoConnectedClientIsANoOp(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 
 	assert.NotPanics(t, func() {
 		hub.PublishAck("nobody-home", uuid.New(), 1)
@@ -71,7 +76,7 @@ func TestHub_PublishAck_NoConnectedClientIsANoOp(t *testing.T) {
 }
 
 func TestHub_PublishAck_FansOutToEveryConnectionOfTheSameClient(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	server := startTestServer(t, hub)
 	connA := dial(t, server, "client-1")
 	connB := dial(t, server, "client-1")
@@ -92,7 +97,7 @@ func TestHub_PublishAck_FansOutToEveryConnectionOfTheSameClient(t *testing.T) {
 }
 
 func TestHub_PingIsAnsweredWithPong(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	server := startTestServer(t, hub)
 	conn := dial(t, server, "client-1")
 
@@ -112,7 +117,7 @@ func TestHub_PingIsAnsweredWithPong(t *testing.T) {
 // re-registered - would wipe out the new connection too, and acks would
 // go nowhere until the next reconnect.
 func TestHub_ReconnectDoesNotLoseTheNewConnection(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 
 	oldConn := newConnection(&websocket.Conn{})
 	hub.register("client-1", oldConn)
@@ -130,7 +135,7 @@ func TestHub_ReconnectDoesNotLoseTheNewConnection(t *testing.T) {
 }
 
 func TestHub_UnregisterRemovesTheClientEntryOnceEmpty(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	conn := newConnection(&websocket.Conn{})
 	hub.register("client-1", conn)
 
@@ -143,7 +148,7 @@ func TestHub_UnregisterRemovesTheClientEntryOnceEmpty(t *testing.T) {
 }
 
 func TestHub_PublishListEvent_DeliversToASubscriber(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	server := startTestServer(t, hub)
 	conn := dial(t, server, "client-1")
 	listID := uuid.New()
@@ -167,7 +172,7 @@ func TestHub_PublishListEvent_DeliversToASubscriber(t *testing.T) {
 }
 
 func TestHub_PublishListEvent_NoSubscriberIsANoOp(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 
 	assert.NotPanics(t, func() {
 		hub.PublishListEvent(uuid.New(), 1)
@@ -175,7 +180,7 @@ func TestHub_PublishListEvent_NoSubscriberIsANoOp(t *testing.T) {
 }
 
 func TestHub_PublishListEvent_DoesNotReachAConnectionSubscribedToAnotherList(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	server := startTestServer(t, hub)
 	subscribed := dial(t, server, "client-1")
 	other := dial(t, server, "client-2")
@@ -209,7 +214,7 @@ func TestHub_PublishListEvent_DoesNotReachAConnectionSubscribedToAnotherList(t *
 }
 
 func TestHub_Subscribe_ReplacesRatherThanAccumulatesPreviousSubscriptions(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	conn := newConnection(&websocket.Conn{})
 	listA := uuid.New()
 	listB := uuid.New()
@@ -222,7 +227,7 @@ func TestHub_Subscribe_ReplacesRatherThanAccumulatesPreviousSubscriptions(t *tes
 }
 
 func TestHub_Unregister_RemovesTheConnectionsSubscriptions(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(testLogger())
 	conn := newConnection(&websocket.Conn{})
 	listID := uuid.New()
 	hub.register("client-1", conn)

--- a/backend/internal/interface/api/middleware/auth.go
+++ b/backend/internal/interface/api/middleware/auth.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -35,7 +35,7 @@ func Passthrough(next echo.HandlerFunc) echo.HandlerFunc {
 //
 // Does not scope data to a user yet (see sync-design-decisions.md): any
 // valid token can still read/write any known list id.
-func NewKeycloakAuth(ctx context.Context) (echo.MiddlewareFunc, error) {
+func NewKeycloakAuth(ctx context.Context, logger *slog.Logger) (echo.MiddlewareFunc, error) {
 	issuer := os.Getenv(envKeycloakIssuer)
 	clientID := os.Getenv(envKeycloakClientID)
 
@@ -49,12 +49,13 @@ func NewKeycloakAuth(ctx context.Context) (echo.MiddlewareFunc, error) {
 	}
 
 	verifier := provider.Verifier(&oidc.Config{SkipClientIDCheck: true})
-	log.Printf("auth: verifying bearer tokens against issuer %s (client %s)", issuer, clientID)
+	logger.Info("auth configured", "issuer", issuer, "client_id", clientID)
 
 	mw := func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			token, ok := bearerToken(c.Request())
 			if !ok {
+				RequestScopedLogger(logger, c).Warn("rejected request", "reason", "missing bearer token")
 				return c.JSON(http.StatusUnauthorized, map[string]string{
 					"error": "missing bearer token",
 				})
@@ -62,6 +63,7 @@ func NewKeycloakAuth(ctx context.Context) (echo.MiddlewareFunc, error) {
 
 			idToken, err := verifier.Verify(c.Request().Context(), token)
 			if err != nil {
+				RequestScopedLogger(logger, c).Warn("rejected request", "reason", "invalid token", "error", err)
 				return c.JSON(http.StatusUnauthorized, map[string]string{
 					"error": "invalid token",
 				})
@@ -70,7 +72,14 @@ func NewKeycloakAuth(ctx context.Context) (echo.MiddlewareFunc, error) {
 			var claims struct {
 				AuthorizedParty string `json:"azp"`
 			}
-			if err := idToken.Claims(&claims); err != nil || claims.AuthorizedParty != clientID {
+			if err := idToken.Claims(&claims); err != nil {
+				RequestScopedLogger(logger, c).Warn("rejected request", "reason", "failed to parse claims", "error", err)
+				return c.JSON(http.StatusUnauthorized, map[string]string{
+					"error": "invalid token",
+				})
+			}
+			if claims.AuthorizedParty != clientID {
+				RequestScopedLogger(logger, c).Warn("rejected request", "reason", "azp mismatch", "azp", claims.AuthorizedParty)
 				return c.JSON(http.StatusUnauthorized, map[string]string{
 					"error": "invalid token",
 				})

--- a/backend/internal/interface/api/middleware/auth_test.go
+++ b/backend/internal/interface/api/middleware/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/require"
 )
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 const (
 	testClientID = "shopping-list"
@@ -145,7 +150,7 @@ func TestNewKeycloakAuth_ValidTokenPasses(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 	token := provider.signToken(t, defaultClaims(provider.issuer(), nil))
@@ -161,7 +166,7 @@ func TestNewKeycloakAuth_MissingTokenReturns401(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 
@@ -176,7 +181,7 @@ func TestNewKeycloakAuth_ExpiredTokenReturns401(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 	token := provider.signToken(t, defaultClaims(provider.issuer(), map[string]any{
@@ -195,7 +200,7 @@ func TestNewKeycloakAuth_WrongSignatureReturns401(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 	// Claims say it's from `provider`'s issuer, but it was actually signed
@@ -214,7 +219,7 @@ func TestNewKeycloakAuth_WrongAzpReturns401(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 	token := provider.signToken(t, defaultClaims(provider.issuer(), map[string]any{
@@ -232,7 +237,7 @@ func TestNewKeycloakAuth_WrongIssuerReturns401(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, provider.issuer())
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 	require.NoError(t, err)
 	e, called := newTestEcho(mw)
 	token := provider.signToken(t, defaultClaims("https://not-the-configured-issuer.example", nil))
@@ -247,7 +252,7 @@ func TestNewKeycloakAuth_MissingConfigReturnsError(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, "")
 	t.Setenv(envKeycloakClientID, "")
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 
 	require.Error(t, err)
 	require.Nil(t, mw)
@@ -257,7 +262,7 @@ func TestNewKeycloakAuth_UnreachableIssuerReturnsError(t *testing.T) {
 	t.Setenv(envKeycloakIssuer, "http://127.0.0.1:1")
 	t.Setenv(envKeycloakClientID, testClientID)
 
-	mw, err := NewKeycloakAuth(context.Background())
+	mw, err := NewKeycloakAuth(context.Background(), testLogger())
 
 	require.Error(t, err)
 	require.Nil(t, mw)

--- a/backend/internal/interface/api/middleware/logging.go
+++ b/backend/internal/interface/api/middleware/logging.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"log/slog"
+
+	"github.com/labstack/echo/v4"
+	echomw "github.com/labstack/echo/v4/middleware"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/logging"
+)
+
+// RequestLogger builds an access-log middleware: one structured line per
+// request, level chosen by response status (>=500 error, >=400 warn, else
+// info). Skips the sync websocket route - those connections live for
+// minutes, and an access-log entry with a multi-minute "latency" would be
+// misleading; the hub logs its own connect/disconnect (see realtime.Hub).
+func RequestLogger(logger *slog.Logger) echo.MiddlewareFunc {
+	return echomw.RequestLoggerWithConfig(echomw.RequestLoggerConfig{
+		Skipper: func(c echo.Context) bool {
+			return c.Path() == "/api/v1/sync/ws"
+		},
+		LogRemoteIP:      true,
+		LogMethod:        true,
+		LogURI:           true,
+		LogStatus:        true,
+		LogLatency:       true,
+		LogUserAgent:     true,
+		LogRequestID:     true,
+		LogContentLength: true,
+		LogResponseSize:  true,
+		LogError:         true,
+		HandleError:      true,
+		LogValuesFunc: func(c echo.Context, v echomw.RequestLoggerValues) error {
+			level := slog.LevelInfo
+			switch {
+			case v.Status >= 500:
+				level = slog.LevelError
+			case v.Status >= 400:
+				level = slog.LevelWarn
+			}
+			logger.LogAttrs(c.Request().Context(), level, "request",
+				slog.String("request_id", v.RequestID),
+				slog.String("remote_ip", v.RemoteIP),
+				slog.String("method", v.Method),
+				slog.String("uri", v.URI),
+				slog.Int("status", v.Status),
+				slog.Duration("latency", v.Latency),
+				slog.String("user_agent", v.UserAgent),
+				slog.String("content_length", v.ContentLength),
+				slog.Int64("response_size", v.ResponseSize),
+				slog.Any("error", v.Error),
+			)
+			return nil
+		},
+	})
+}
+
+// ContextLogger stashes a request-scoped logger (tagged with request_id) in
+// the request context, so anything downstream that receives ctx - repos,
+// the event ingestor's Enqueue - can log with the same correlation id
+// without threading a logger through every call.
+func ContextLogger(logger *slog.Logger) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			requestLogger := logger.With("request_id", c.Response().Header().Get(echo.HeaderXRequestID))
+			c.SetRequest(c.Request().WithContext(logging.NewContext(c.Request().Context(), requestLogger)))
+			return next(c)
+		}
+	}
+}
+
+// RequestScopedLogger returns a logger tagged with the current request's id
+// and, once authenticated, its user id (see middleware.NewKeycloakAuth) -
+// the shared helper every REST controller uses so 500 paths log with
+// consistent correlation fields instead of copy-pasted attribute lists.
+func RequestScopedLogger(base *slog.Logger, c echo.Context) *slog.Logger {
+	l := base.With("request_id", c.Response().Header().Get(echo.HeaderXRequestID))
+	if userID, ok := c.Get("user_id").(string); ok && userID != "" {
+		l = l.With("user_id", userID)
+	}
+	return l
+}

--- a/backend/internal/interface/api/rest/event-controller.go
+++ b/backend/internal/interface/api/rest/event-controller.go
@@ -1,19 +1,22 @@
 package rest
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/services"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/request"
 )
 
 type EventController struct {
+	logger   *slog.Logger
 	ingestor *services.EventIngestor
 }
 
-func NewEventController(e *echo.Echo, ingestor *services.EventIngestor, authMW echo.MiddlewareFunc) *EventController {
-	controller := &EventController{ingestor: ingestor}
+func NewEventController(e *echo.Echo, logger *slog.Logger, ingestor *services.EventIngestor, authMW echo.MiddlewareFunc) *EventController {
+	controller := &EventController{logger: logger, ingestor: ingestor}
 	e.POST("/api/v1/events", controller.SyncEvents, authMW)
 	return controller
 }
@@ -38,6 +41,7 @@ func (ec *EventController) SyncEvents(c echo.Context) error {
 	ctx := c.Request().Context()
 	for _, event := range events {
 		if err := ec.ingestor.Enqueue(ctx, event.ToStoredEvent()); err != nil {
+			middleware.RequestScopedLogger(ec.logger, c).Error("failed to queue event", "event_id", event.EventID, "error", err)
 			return c.JSON(http.StatusInternalServerError, map[string]string{
 				"error": "Failed to queue event",
 			})

--- a/backend/internal/interface/api/rest/event-controller_test.go
+++ b/backend/internal/interface/api/rest/event-controller_test.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,6 +18,11 @@ import (
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 )
+
+// testLogger is shared by every *_test.go file in this package.
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
 
 // fakeEventRepo/fakeAckPublisher mirror the ones in
 // internal/application/services/event-ingestor_test.go, kept minimal and
@@ -77,8 +83,8 @@ func (f *fakeAckPublisher) PublishListEvent(listID uuid.UUID, seq int64) {}
 func TestEventController_SyncEvents_QueuesEventsAndReturns202(t *testing.T) {
 	repo := newFakeEventRepo()
 	ack := &fakeAckPublisher{acked: map[uuid.UUID]bool{}}
-	dispatcher := services.NewEventDispatcher()
-	ingestor := services.NewEventIngestor(repo, dispatcher, ack)
+	dispatcher := services.NewEventDispatcher(testLogger())
+	ingestor := services.NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -86,7 +92,7 @@ func TestEventController_SyncEvents_QueuesEventsAndReturns202(t *testing.T) {
 	defer ingestor.Stop()
 
 	e := echo.New()
-	NewEventController(e, ingestor, middleware.Passthrough)
+	NewEventController(e, testLogger(), ingestor, middleware.Passthrough)
 
 	eventID := uuid.New()
 	aggregateID := uuid.New()
@@ -117,8 +123,8 @@ func TestEventController_SyncEvents_QueuesEventsAndReturns202(t *testing.T) {
 func TestEventController_SyncEvents_MalformedBodyReturns400(t *testing.T) {
 	repo := newFakeEventRepo()
 	ack := &fakeAckPublisher{acked: map[uuid.UUID]bool{}}
-	dispatcher := services.NewEventDispatcher()
-	ingestor := services.NewEventIngestor(repo, dispatcher, ack)
+	dispatcher := services.NewEventDispatcher(testLogger())
+	ingestor := services.NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -126,7 +132,7 @@ func TestEventController_SyncEvents_MalformedBodyReturns400(t *testing.T) {
 	defer ingestor.Stop()
 
 	e := echo.New()
-	NewEventController(e, ingestor, middleware.Passthrough)
+	NewEventController(e, testLogger(), ingestor, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`{not valid json`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -140,8 +146,8 @@ func TestEventController_SyncEvents_MalformedBodyReturns400(t *testing.T) {
 func TestEventController_SyncEvents_EmptyBatchReturns202WithZeroQueued(t *testing.T) {
 	repo := newFakeEventRepo()
 	ack := &fakeAckPublisher{acked: map[uuid.UUID]bool{}}
-	dispatcher := services.NewEventDispatcher()
-	ingestor := services.NewEventIngestor(repo, dispatcher, ack)
+	dispatcher := services.NewEventDispatcher(testLogger())
+	ingestor := services.NewEventIngestor(testLogger(), repo, dispatcher, ack)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -149,7 +155,7 @@ func TestEventController_SyncEvents_EmptyBatchReturns202WithZeroQueued(t *testin
 	defer ingestor.Stop()
 
 	e := echo.New()
-	NewEventController(e, ingestor, middleware.Passthrough)
+	NewEventController(e, testLogger(), ingestor, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(`[]`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/backend/internal/interface/api/rest/sync-pull-controller.go
+++ b/backend/internal/interface/api/rest/sync-pull-controller.go
@@ -1,12 +1,14 @@
 package rest
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/mapper"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/request"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/response"
@@ -18,15 +20,17 @@ const (
 )
 
 type SyncPullController struct {
+	logger    *slog.Logger
 	eventRepo repositories.EventRepository
 }
 
 func NewSyncPullController(
 	e *echo.Echo,
+	logger *slog.Logger,
 	eventRepo repositories.EventRepository,
 	authMW echo.MiddlewareFunc,
 ) *SyncPullController {
-	controller := &SyncPullController{eventRepo: eventRepo}
+	controller := &SyncPullController{logger: logger, eventRepo: eventRepo}
 	e.POST("/api/v1/sync/head", controller.GetHead, authMW)
 	e.GET("/api/v1/sync/events", controller.GetEvents, authMW)
 	return controller
@@ -56,6 +60,7 @@ func (spc *SyncPullController) GetHead(c echo.Context) error {
 
 	heads, err := spc.eventRepo.FindListHeads(c.Request().Context(), req.ListIDs)
 	if err != nil {
+		middleware.RequestScopedLogger(spc.logger, c).Error("failed to look up list heads", "list_ids", req.ListIDs, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to look up list heads",
 		})
@@ -121,6 +126,9 @@ func (spc *SyncPullController) GetEvents(c echo.Context) error {
 
 	events, err := spc.eventRepo.FindEventsSince(c.Request().Context(), listID, sinceSeq, limit)
 	if err != nil {
+		middleware.RequestScopedLogger(spc.logger, c).Error(
+			"failed to load events", "list_id", listID, "since_seq", sinceSeq, "error", err,
+		)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to load events",
 		})

--- a/backend/internal/interface/api/rest/sync-pull-controller_test.go
+++ b/backend/internal/interface/api/rest/sync-pull-controller_test.go
@@ -77,7 +77,7 @@ func TestSyncPullController_GetHead_EveryRequestedListIDAppearsInTheResponse(t *
 	}
 
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	body := fmt.Sprintf(`{"list_ids":["%s","%s"]}`, knownList, unknownList)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/head", strings.NewReader(body))
@@ -96,7 +96,7 @@ func TestSyncPullController_GetHead_EveryRequestedListIDAppearsInTheResponse(t *
 func TestSyncPullController_GetHead_MalformedBodyReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/head", strings.NewReader(`{not valid`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -110,7 +110,7 @@ func TestSyncPullController_GetHead_MalformedBodyReturns400(t *testing.T) {
 func TestSyncPullController_GetHead_TooManyListIDsReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	ids := make([]string, maxSyncListIDs+1)
 	for i := range ids {
@@ -134,7 +134,7 @@ func TestSyncPullController_GetHead_RepositoryErrorReturns500(t *testing.T) {
 		},
 	}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/head", strings.NewReader(`{"list_ids":[]}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -148,7 +148,7 @@ func TestSyncPullController_GetHead_RepositoryErrorReturns500(t *testing.T) {
 func TestSyncPullController_GetEvents_MissingListIDReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync/events", nil)
 	rec := httptest.NewRecorder()
@@ -161,7 +161,7 @@ func TestSyncPullController_GetEvents_MissingListIDReturns400(t *testing.T) {
 func TestSyncPullController_GetEvents_InvalidListIDReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/sync/events?list_id=not-a-uuid", nil)
 	rec := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestSyncPullController_GetEvents_InvalidListIDReturns400(t *testing.T) {
 func TestSyncPullController_GetEvents_InvalidSinceSeqReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	listID := uuid.New()
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s&since_seq=not-a-number", listID), nil)
@@ -188,7 +188,7 @@ func TestSyncPullController_GetEvents_InvalidSinceSeqReturns400(t *testing.T) {
 func TestSyncPullController_GetEvents_InvalidLimitReturns400(t *testing.T) {
 	repo := &stubPullEventRepository{}
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	listID := uuid.New()
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s&limit=0", listID), nil)
@@ -223,7 +223,7 @@ func TestSyncPullController_GetEvents_HasMoreWhenPageIsFull(t *testing.T) {
 	}
 
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s&limit=1", listID), nil)
 	rec := httptest.NewRecorder()
@@ -254,7 +254,7 @@ func TestSyncPullController_GetEvents_NoMoreWhenPageIsShort(t *testing.T) {
 	}
 
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s", listID), nil)
 	rec := httptest.NewRecorder()
@@ -277,7 +277,7 @@ func TestSyncPullController_GetEvents_ClampsLimitAboveTheMax(t *testing.T) {
 	}
 
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s&limit=10000", listID), nil)
 	rec := httptest.NewRecorder()
@@ -296,7 +296,7 @@ func TestSyncPullController_GetEvents_RepositoryErrorReturns500(t *testing.T) {
 	}
 
 	e := echo.New()
-	NewSyncPullController(e, repo, middleware.Passthrough)
+	NewSyncPullController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sync/events?list_id=%s", uuid.New()), nil)
 	rec := httptest.NewRecorder()

--- a/backend/internal/interface/api/rest/sync-state-controller.go
+++ b/backend/internal/interface/api/rest/sync-state-controller.go
@@ -1,11 +1,13 @@
 package rest
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/request"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/response"
 )
@@ -18,15 +20,17 @@ import (
 const maxSyncListIDs = 200
 
 type SyncStateController struct {
+	logger    *slog.Logger
 	eventRepo repositories.EventRepository
 }
 
 func NewSyncStateController(
 	e *echo.Echo,
+	logger *slog.Logger,
 	eventRepo repositories.EventRepository,
 	authMW echo.MiddlewareFunc,
 ) *SyncStateController {
-	controller := &SyncStateController{eventRepo: eventRepo}
+	controller := &SyncStateController{logger: logger, eventRepo: eventRepo}
 	e.POST("/api/v1/sync/state", controller.GetSyncState, authMW)
 	return controller
 }
@@ -53,6 +57,7 @@ func (ssc *SyncStateController) GetSyncState(c echo.Context) error {
 
 	knownEventIDs, err := ssc.eventRepo.FindKnownEventIDsByList(c.Request().Context(), req.ListIDs)
 	if err != nil {
+		middleware.RequestScopedLogger(ssc.logger, c).Error("failed to look up sync state", "list_ids", req.ListIDs, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to look up sync state",
 		})

--- a/backend/internal/interface/api/rest/sync-state-controller_test.go
+++ b/backend/internal/interface/api/rest/sync-state-controller_test.go
@@ -72,7 +72,7 @@ func TestSyncStateController_ReturnsKnownEventIDsForRequestedLists(t *testing.T)
 	}
 
 	e := echo.New()
-	NewSyncStateController(e, repo, middleware.Passthrough)
+	NewSyncStateController(e, testLogger(), repo, middleware.Passthrough)
 
 	body := fmt.Sprintf(`{"list_ids":["%s","%s"]}`, knownList, unknownList)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/state", strings.NewReader(body))
@@ -88,7 +88,7 @@ func TestSyncStateController_ReturnsKnownEventIDsForRequestedLists(t *testing.T)
 func TestSyncStateController_MalformedBodyReturns400(t *testing.T) {
 	repo := &stubEventRepository{}
 	e := echo.New()
-	NewSyncStateController(e, repo, middleware.Passthrough)
+	NewSyncStateController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/state", strings.NewReader(`{not valid`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -102,7 +102,7 @@ func TestSyncStateController_MalformedBodyReturns400(t *testing.T) {
 func TestSyncStateController_TooManyListIDsReturns400(t *testing.T) {
 	repo := &stubEventRepository{}
 	e := echo.New()
-	NewSyncStateController(e, repo, middleware.Passthrough)
+	NewSyncStateController(e, testLogger(), repo, middleware.Passthrough)
 
 	ids := make([]string, maxSyncListIDs+1)
 	for i := range ids {
@@ -126,7 +126,7 @@ func TestSyncStateController_RepositoryErrorReturns500(t *testing.T) {
 		},
 	}
 	e := echo.New()
-	NewSyncStateController(e, repo, middleware.Passthrough)
+	NewSyncStateController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/state", strings.NewReader(`{"list_ids":[]}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -144,7 +144,7 @@ func TestSyncStateController_EmptyListIDsReturnsEmptyList(t *testing.T) {
 		},
 	}
 	e := echo.New()
-	NewSyncStateController(e, repo, middleware.Passthrough)
+	NewSyncStateController(e, testLogger(), repo, middleware.Passthrough)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sync/state", strings.NewReader(`{"list_ids":[]}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/backend/internal/interface/api/rest/todo-list-controller.go
+++ b/backend/internal/interface/api/rest/todo-list-controller.go
@@ -1,23 +1,26 @@
 package rest
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/command"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/mapper"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/request"
 )
 
 type ToDoListController struct {
+	logger  *slog.Logger
 	service interfaces.ToDoListService
 }
 
-func NewToDoListController(e *echo.Echo, service interfaces.ToDoListService) *ToDoListController {
+func NewToDoListController(e *echo.Echo, logger *slog.Logger, service interfaces.ToDoListService) *ToDoListController {
 	controller := &ToDoListController{
+		logger:  logger,
 		service: service,
 	}
 
@@ -25,7 +28,6 @@ func NewToDoListController(e *echo.Echo, service interfaces.ToDoListService) *To
 	e.GET("/api/v1/todo-lists", controller.GetAllToDoListsController)
 	e.PUT("/api/v1/todo-lists/:id", controller.UpdateToDoListController)
 	e.DELETE("/api/v1/todo-lists/:id", controller.DeleteToDoListController)
-	e.Use(middleware.Recover())
 
 	return controller
 }
@@ -48,6 +50,7 @@ func (pc *ToDoListController) CreateToDoListController(c echo.Context) error {
 
 	result, err := pc.service.CreateToDoList(toDoListCommand)
 	if err != nil {
+		middleware.RequestScopedLogger(pc.logger, c).Error("failed to create todo list", "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to create ToDoList",
 		})
@@ -61,6 +64,7 @@ func (pc *ToDoListController) CreateToDoListController(c echo.Context) error {
 func (pc *ToDoListController) GetAllToDoListsController(c echo.Context) error {
 	toDoLists, err := pc.service.FindAllToDoLists()
 	if err != nil {
+		middleware.RequestScopedLogger(pc.logger, c).Error("failed to fetch todo lists", "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to fetch ToDoLists",
 		})
@@ -88,6 +92,7 @@ func (pc *ToDoListController) UpdateToDoListController(c echo.Context) error {
 
 	result, err := pc.service.UpdateToDoList(updateRequest.ToUpdateToDoListCommand(id))
 	if err != nil {
+		middleware.RequestScopedLogger(pc.logger, c).Error("failed to update todo list", "id", id, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to update ToDoList",
 		})
@@ -107,6 +112,7 @@ func (pc *ToDoListController) DeleteToDoListController(c echo.Context) error {
 
 	_, err = pc.service.DeleteToDoList(&command.DeleteToDoListCommand{Id: id})
 	if err != nil {
+		middleware.RequestScopedLogger(pc.logger, c).Error("failed to delete todo list", "id", id, "error", err)
 		return c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": "Failed to delete ToDoList",
 		})


### PR DESCRIPTION
## Summary
- Replaces unstructured `log.Printf`/`log.Fatalf` with `log/slog`-based JSON logging (stdout, `LOG_LEVEL`/`LOG_FORMAT` env-configurable), injected via DI into every service/controller that logs.
- Adds request-id correlated access logging (Echo `RequestID` + `RequestLogger` middleware) and a custom `HTTPErrorHandler`/`Recover` config so panics and errors that bypass a controller's own JSON response are logged too.
- Logs previously-silent cases: all controller 500 paths, unknown event types (forward-compat no-op), and the schema-migration runner (which previously logged via plain `log.Printf`).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- [x] `go test ./...` passes (incl. new `logging` package tests and a new log-assertion test in `event-ingestor_test.go`)
- [x] Verified live against the real dev stack (Postgres + hosted Keycloak): pure JSON stdout, `request_id` correlates access-log/auth-warn/error lines, a genuine 500 now logs the real error where before it was silent, `LOG_LEVEL=warn` suppresses info noise, `LOG_FORMAT=text` works