### PR TITLE
fix(renovate): drop per-area concurrent limits

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,7 @@
     'helpers:pinGitHubActionDigestsToSemver',
   ],
   prConcurrentLimit: 0,
+  prHourlyLimit: 0,
   packageRules: [
     {
       matchUpdateTypes: [
@@ -17,7 +18,6 @@
       matchFileNames: [
         'frontend/**',
       ],
-      prConcurrentLimit: 10,
       addLabels: [
         'frontend',
       ],
@@ -26,7 +26,6 @@
       matchFileNames: [
         'backend/**',
       ],
-      prConcurrentLimit: 10,
       addLabels: [
         'backend',
       ],


### PR DESCRIPTION
prConcurrentLimit is counted repo-wide across all renovate/* branches, not per packageRule, so the frontend/backend overrides of 10 were silently capping the *global* branch count. With 11+ open branches across all areas this permanently blocked new backend branches from being created. Drop the per-area overrides and disable prHourlyLimit too so the daily cron can clear the backlog in one run instead of 2 PRs/day.