### PR TITLE
Group backend Go version updates from go.mod and Dockerfile

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -65,6 +65,34 @@
       groupSlug: 'expo-sdk',
       rangeStrategy: 'replace',
     },
+    {
+      // aktiviert Updates der `go`-Direktive in go.mod (per Default deaktiviert)
+      matchDatasources: [
+        'golang-version',
+      ],
+      matchDepNames: [
+        'go',
+      ],
+      rangeStrategy: 'bump',
+    },
+    {
+      // Go-Version in backend/go.mod und im golang-Image in backend/Dockerfile gemeinsam anheben
+      matchDatasources: [
+        'golang-version',
+        'docker',
+      ],
+      matchDepNames: [
+        'go',
+        'golang',
+      ],
+      matchUpdateTypes: [
+        'major',
+        'minor',
+        'patch',
+      ],
+      groupName: 'go version',
+      groupSlug: 'go-version',
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary
- The `go` directive in `backend/go.mod` was never updated by Renovate (disabled by default), so it could drift from the `golang` image tag in `backend/Dockerfile`.
- Adds a packageRule enabling `rangeStrategy: bump` for the go.mod `go` directive.
- Adds a packageRule grouping the go.mod `go` directive and the Dockerfile `golang` image (version/minor/patch updates only, not digest-only refreshes) into a single `go version` PR.

## Test plan
- [x] `pnpm dlx --package renovate -- renovate-config-validator --no-global renovate.json5` → `Config validated successfully`
- [x] `pnpm dlx --package renovate -- renovate --platform=local --dry-run=lookup` against this repo confirms both `go` (go.mod) and `golang` (Dockerfile) resolve into the same `renovate/go-version` branch