### PR TITLE
feat(backend): list sharing business logic (invite links)

### DIFF
--- a/backend/internal/application/command/create-list-invite-command.go
+++ b/backend/internal/application/command/create-list-invite-command.go
@@ -1,0 +1,21 @@
+package command
+
+import (
+	"github.com/google/uuid"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/common"
+)
+
+type CreateListInviteCommand struct {
+	ListID uuid.UUID
+	// UserID is the caller's verified Keycloak subject - never taken from
+	// the request body, see sync-design-decisions.md.
+	UserID string
+	TTLKey string
+}
+
+type CreateListInviteCommandResult struct {
+	Result *common.ListInviteResult
+	// Token is the plaintext invite token - present only in this, the
+	// create result. Never persisted, never returned again afterwards.
+	Token string
+}

--- a/backend/internal/application/command/redeem-list-invite-command.go
+++ b/backend/internal/application/command/redeem-list-invite-command.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/google/uuid"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+)
+
+type RedeemListInviteCommand struct {
+	Token string
+	// UserID is the caller's verified Keycloak subject - never taken from
+	// the request body.
+	UserID string
+}
+
+type RedeemListInviteCommandResult struct {
+	ListID   uuid.UUID
+	ListName string
+	Role     entities.ListMemberRole
+	// AlreadyMember is true when the caller was already a member of the
+	// list before this redeem - a successful no-op, not an error.
+	AlreadyMember bool
+}

--- a/backend/internal/application/command/revoke-list-invite-command.go
+++ b/backend/internal/application/command/revoke-list-invite-command.go
@@ -1,0 +1,12 @@
+package command
+
+import "github.com/google/uuid"
+
+type RevokeListInviteCommand struct {
+	InviteID uuid.UUID
+	// UserID is the caller's verified Keycloak subject - never taken from
+	// the request body.
+	UserID string
+}
+
+type RevokeListInviteCommandResult struct{}

--- a/backend/internal/application/common/list-invite-result.go
+++ b/backend/internal/application/common/list-invite-result.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ListInviteResult is the invite DTO used everywhere except the moment of
+// creation - it deliberately carries no token, see CreateListInviteResult.
+type ListInviteResult struct {
+	ID        uuid.UUID `json:"id"`
+	ListID    uuid.UUID `json:"list_id"`
+	CreatedBy string    `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}

--- a/backend/internal/application/interfaces/list-sharing-service.go
+++ b/backend/internal/application/interfaces/list-sharing-service.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrListNotFound       = errors.New("todo list not found")
 	ErrNotAListMember     = errors.New("caller is not a member of this list")
+	ErrNotListOwner       = errors.New("caller is not the owner of this list")
 	ErrInvalidInviteTTL   = errors.New("invalid invite ttl")
 	ErrInviteNotFound     = errors.New("invite not found")
 	ErrInviteExpired      = errors.New("invite has expired")

--- a/backend/internal/application/interfaces/list-sharing-service.go
+++ b/backend/internal/application/interfaces/list-sharing-service.go
@@ -1,6 +1,7 @@
 package interfaces
 
 import (
+	"context"
 	"errors"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/command"
@@ -14,6 +15,7 @@ import (
 var (
 	ErrListNotFound       = errors.New("todo list not found")
 	ErrNotAListMember     = errors.New("caller is not a member of this list")
+	ErrInvalidInviteTTL   = errors.New("invalid invite ttl")
 	ErrInviteNotFound     = errors.New("invite not found")
 	ErrInviteExpired      = errors.New("invite has expired")
 	ErrInviteRevoked      = errors.New("invite has been revoked")
@@ -21,8 +23,8 @@ var (
 )
 
 type ListSharingService interface {
-	CreateInvite(cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error)
-	FindActiveInvites(qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error)
-	RevokeInvite(cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error)
-	RedeemInvite(cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error)
+	CreateInvite(ctx context.Context, cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error)
+	FindActiveInvites(ctx context.Context, qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error)
+	RevokeInvite(ctx context.Context, cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error)
+	RedeemInvite(ctx context.Context, cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error)
 }

--- a/backend/internal/application/interfaces/list-sharing-service.go
+++ b/backend/internal/application/interfaces/list-sharing-service.go
@@ -1,0 +1,28 @@
+package interfaces
+
+import (
+	"errors"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/command"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/query"
+)
+
+// Sentinel errors ListSharingService returns, so callers (the REST
+// controller, in a later PR) can map them to specific HTTP statuses instead
+// of collapsing every failure to 500 like the older services in this
+// package do.
+var (
+	ErrListNotFound       = errors.New("todo list not found")
+	ErrNotAListMember     = errors.New("caller is not a member of this list")
+	ErrInviteNotFound     = errors.New("invite not found")
+	ErrInviteExpired      = errors.New("invite has expired")
+	ErrInviteRevoked      = errors.New("invite has been revoked")
+	ErrInviteNotRevocable = errors.New("caller may not revoke this invite")
+)
+
+type ListSharingService interface {
+	CreateInvite(cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error)
+	FindActiveInvites(qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error)
+	RevokeInvite(cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error)
+	RedeemInvite(cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error)
+}

--- a/backend/internal/application/mapper/list-invite-result.go
+++ b/backend/internal/application/mapper/list-invite-result.go
@@ -1,0 +1,16 @@
+package mapper
+
+import (
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/common"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+)
+
+func NewListInviteResultFromEntity(invite *entities.ListInvite) *common.ListInviteResult {
+	return &common.ListInviteResult{
+		ID:        invite.ID,
+		ListID:    invite.ListID,
+		CreatedBy: invite.CreatedBy,
+		CreatedAt: invite.CreatedAt,
+		ExpiresAt: invite.ExpiresAt,
+	}
+}

--- a/backend/internal/application/query/get-list-invites-query.go
+++ b/backend/internal/application/query/get-list-invites-query.go
@@ -1,0 +1,17 @@
+package query
+
+import (
+	"github.com/google/uuid"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/common"
+)
+
+type GetListInvitesQuery struct {
+	ListID uuid.UUID
+	// UserID is the caller's verified Keycloak subject - never taken from
+	// the request body.
+	UserID string
+}
+
+type GetListInvitesQueryResult struct {
+	Result []*common.ListInviteResult
+}

--- a/backend/internal/application/services/list-sharing-service.go
+++ b/backend/internal/application/services/list-sharing-service.go
@@ -42,8 +42,12 @@ func NewListSharingService(
 // claimed, so merely listing or revoking invites can't grant it), then
 // requires the caller to actually be a member.
 func (s *ListSharingService) claimOrRequireMember(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
-	if _, err := s.members.ClaimOwnershipIfUnowned(ctx, listID, userID, now); err != nil {
+	claimed, err := s.members.ClaimOwnershipIfUnowned(ctx, listID, userID, now)
+	if err != nil {
 		return err
+	}
+	if claimed {
+		return nil
 	}
 	return s.requireMember(ctx, listID, userID)
 }
@@ -159,6 +163,29 @@ func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.Rede
 		return nil, interfaces.ErrInviteNotFound
 	}
 
+	// The list may have been deleted since this invite was created; a
+	// deleted list can't be joined.
+	list, err := s.requireList(invite.ListID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Idempotency check comes before the revoked/expired check: a caller
+	// who already joined must be able to safely retry redeem (e.g. after a
+	// lost response) even if the token has since been revoked or expired -
+	// at that point it's only re-identifying them, not authorizing a new
+	// join. Revocation/expiry only ever blocks *new* joins.
+	if existing, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return &command.RedeemListInviteCommandResult{
+			ListID:        invite.ListID,
+			ListName:      list.Name,
+			Role:          existing.Role,
+			AlreadyMember: true,
+		}, nil
+	}
+
 	now := time.Now().UTC()
 	if invite.RevokedAt != nil {
 		return nil, interfaces.ErrInviteRevoked
@@ -167,37 +194,19 @@ func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.Rede
 		return nil, interfaces.ErrInviteExpired
 	}
 
-	// The list may have been deleted since this invite was created; a
-	// deleted list can't be joined.
-	list, err := s.requireList(invite.ListID)
+	inviteID := invite.ID
+	member, err := entities.NewListMember(invite.ListID, cmd.UserID, entities.RoleMember, now, &inviteID)
 	if err != nil {
 		return nil, err
 	}
-
-	existing, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID)
-	if err != nil {
+	if err := s.members.Add(ctx, member); err != nil {
 		return nil, err
-	}
-
-	role := entities.RoleMember
-	alreadyMember := existing != nil
-	if alreadyMember {
-		role = existing.Role
-	} else {
-		inviteID := invite.ID
-		member, err := entities.NewListMember(invite.ListID, cmd.UserID, entities.RoleMember, now, &inviteID)
-		if err != nil {
-			return nil, err
-		}
-		if err := s.members.Add(ctx, member); err != nil {
-			return nil, err
-		}
 	}
 
 	return &command.RedeemListInviteCommandResult{
 		ListID:        invite.ListID,
 		ListName:      list.Name,
-		Role:          role,
-		AlreadyMember: alreadyMember,
+		Role:          entities.RoleMember,
+		AlreadyMember: false,
 	}, nil
 }

--- a/backend/internal/application/services/list-sharing-service.go
+++ b/backend/internal/application/services/list-sharing-service.go
@@ -37,11 +37,12 @@ func NewListSharingService(
 	}
 }
 
-// claimOrRequireMember bootstraps the caller as owner if the list has no
+// claimOrRequireOwner bootstraps the caller as owner if the list has no
 // members yet (claim-on-first-invite - the only place ownership is ever
 // claimed, so merely listing or revoking invites can't grant it), then
-// requires the caller to actually be a member.
-func (s *ListSharingService) claimOrRequireMember(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
+// requires the caller to actually be the owner - sharing (creating invites)
+// is an owner-only action, not something any member can do once joined.
+func (s *ListSharingService) claimOrRequireOwner(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
 	claimed, err := s.members.ClaimOwnershipIfUnowned(ctx, listID, userID, now)
 	if err != nil {
 		return err
@@ -49,17 +50,23 @@ func (s *ListSharingService) claimOrRequireMember(ctx context.Context, listID uu
 	if claimed {
 		return nil
 	}
-	return s.requireMember(ctx, listID, userID)
+	return s.requireOwner(ctx, listID, userID)
 }
 
-// requireMember checks existing membership without claiming ownership.
-func (s *ListSharingService) requireMember(ctx context.Context, listID uuid.UUID, userID string) error {
+// requireOwner checks the caller is the list's owner without claiming
+// ownership. Distinguishes "not a member at all" from "a member, but not
+// the owner" since only the latter is really about the owner-only action
+// being attempted.
+func (s *ListSharingService) requireOwner(ctx context.Context, listID uuid.UUID, userID string) error {
 	member, err := s.members.FindByListAndUser(ctx, listID, userID)
 	if err != nil {
 		return err
 	}
 	if member == nil {
 		return interfaces.ErrNotAListMember
+	}
+	if member.Role != entities.RoleOwner {
+		return interfaces.ErrNotListOwner
 	}
 	return nil
 }
@@ -86,7 +93,7 @@ func (s *ListSharingService) CreateInvite(ctx context.Context, cmd *command.Crea
 	}
 
 	now := time.Now().UTC()
-	if err := s.claimOrRequireMember(ctx, cmd.ListID, cmd.UserID, now); err != nil {
+	if err := s.claimOrRequireOwner(ctx, cmd.ListID, cmd.UserID, now); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +119,7 @@ func (s *ListSharingService) FindActiveInvites(ctx context.Context, qry *query.G
 
 	// Read-only: must not claim ownership of an unowned list just because
 	// someone asked to list its invites.
-	if err := s.requireMember(ctx, qry.ListID, qry.UserID); err != nil {
+	if err := s.requireOwner(ctx, qry.ListID, qry.UserID); err != nil {
 		return nil, err
 	}
 
@@ -137,14 +144,15 @@ func (s *ListSharingService) RevokeInvite(ctx context.Context, cmd *command.Revo
 		return nil, interfaces.ErrInviteNotFound
 	}
 
-	if invite.CreatedBy != cmd.UserID {
-		member, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID)
-		if err != nil {
-			return nil, err
-		}
-		if member == nil || member.Role != entities.RoleOwner {
-			return nil, interfaces.ErrInviteNotRevocable
-		}
+	// Only the owner may revoke - and since CreateInvite is now itself
+	// owner-only, the creator and the owner are always the same caller, so
+	// there's no separate "or the creator" case to check anymore.
+	member, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if member == nil || member.Role != entities.RoleOwner {
+		return nil, interfaces.ErrInviteNotRevocable
 	}
 
 	if err := s.invites.Revoke(ctx, cmd.InviteID, time.Now().UTC()); err != nil {

--- a/backend/internal/application/services/list-sharing-service.go
+++ b/backend/internal/application/services/list-sharing-service.go
@@ -1,0 +1,203 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/command"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/mapper"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/query"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
+)
+
+type ListSharingService struct {
+	logger    *slog.Logger
+	invites   repositories.ListInviteRepository
+	members   repositories.ListMemberRepository
+	todoLists repositories.ToDoListRepository
+}
+
+func NewListSharingService(
+	logger *slog.Logger,
+	invites repositories.ListInviteRepository,
+	members repositories.ListMemberRepository,
+	todoLists repositories.ToDoListRepository,
+) interfaces.ListSharingService {
+	return &ListSharingService{
+		logger:    logger,
+		invites:   invites,
+		members:   members,
+		todoLists: todoLists,
+	}
+}
+
+// ensureMember bootstraps the caller as owner if the list has no members
+// yet (claim-on-first-invite, see list-member-repository.go), then requires
+// the caller to actually be a member - so anyone who already knows a list's
+// UUID can't invite/list-invites for a list someone else already claimed.
+func (s *ListSharingService) ensureMember(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
+	if _, err := s.members.ClaimOwnershipIfUnowned(ctx, listID, userID, now); err != nil {
+		return err
+	}
+
+	member, err := s.members.FindByListAndUser(ctx, listID, userID)
+	if err != nil {
+		return err
+	}
+	if member == nil {
+		return interfaces.ErrNotAListMember
+	}
+	return nil
+}
+
+func (s *ListSharingService) requireList(listID uuid.UUID) (*entities.ToDoList, error) {
+	list, err := s.todoLists.FindById(listID)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil {
+		return nil, interfaces.ErrListNotFound
+	}
+	return list, nil
+}
+
+func (s *ListSharingService) CreateInvite(cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error) {
+	ttl, err := entities.ParseInviteTTL(cmd.TTLKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := s.requireList(cmd.ListID); err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.ensureMember(ctx, cmd.ListID, cmd.UserID, now); err != nil {
+		return nil, err
+	}
+
+	invite, token, err := entities.NewListInvite(cmd.ListID, cmd.UserID, ttl, now)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.invites.Create(ctx, invite); err != nil {
+		return nil, err
+	}
+
+	return &command.CreateListInviteCommandResult{
+		Result: mapper.NewListInviteResultFromEntity(invite),
+		Token:  string(token),
+	}, nil
+}
+
+func (s *ListSharingService) FindActiveInvites(qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error) {
+	if _, err := s.requireList(qry.ListID); err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.ensureMember(ctx, qry.ListID, qry.UserID, now); err != nil {
+		return nil, err
+	}
+
+	invites, err := s.invites.FindActiveByList(ctx, qry.ListID, now)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &query.GetListInvitesQueryResult{}
+	for _, invite := range invites {
+		result.Result = append(result.Result, mapper.NewListInviteResultFromEntity(invite))
+	}
+	return result, nil
+}
+
+func (s *ListSharingService) RevokeInvite(cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error) {
+	ctx := context.Background()
+
+	invite, err := s.invites.FindByID(ctx, cmd.InviteID)
+	if err != nil {
+		return nil, err
+	}
+	if invite == nil {
+		return nil, interfaces.ErrInviteNotFound
+	}
+
+	if invite.CreatedBy != cmd.UserID {
+		member, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID)
+		if err != nil {
+			return nil, err
+		}
+		if member == nil || member.Role != entities.RoleOwner {
+			return nil, interfaces.ErrInviteNotRevocable
+		}
+	}
+
+	if err := s.invites.Revoke(ctx, cmd.InviteID, time.Now().UTC()); err != nil {
+		return nil, err
+	}
+
+	return &command.RevokeListInviteCommandResult{}, nil
+}
+
+func (s *ListSharingService) RedeemInvite(cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error) {
+	ctx := context.Background()
+
+	invite, err := s.invites.FindByTokenHash(ctx, entities.HashInviteToken(cmd.Token))
+	if err != nil {
+		return nil, err
+	}
+	if invite == nil {
+		return nil, interfaces.ErrInviteNotFound
+	}
+
+	now := time.Now().UTC()
+	if invite.RevokedAt != nil {
+		return nil, interfaces.ErrInviteRevoked
+	}
+	if !invite.ExpiresAt.After(now) {
+		return nil, interfaces.ErrInviteExpired
+	}
+
+	// The list may have been deleted since this invite was created; a
+	// deleted list can't be joined.
+	list, err := s.requireList(invite.ListID)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := s.members.FindByListAndUser(ctx, invite.ListID, cmd.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	role := entities.RoleMember
+	alreadyMember := existing != nil
+	if alreadyMember {
+		role = existing.Role
+	} else {
+		inviteID := invite.ID
+		member, err := entities.NewListMember(invite.ListID, cmd.UserID, entities.RoleMember, now, &inviteID)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.members.Add(ctx, member); err != nil {
+			return nil, err
+		}
+	}
+
+	return &command.RedeemListInviteCommandResult{
+		ListID:        invite.ListID,
+		ListName:      list.Name,
+		Role:          role,
+		AlreadyMember: alreadyMember,
+	}, nil
+}

--- a/backend/internal/application/services/list-sharing-service.go
+++ b/backend/internal/application/services/list-sharing-service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -36,15 +37,19 @@ func NewListSharingService(
 	}
 }
 
-// ensureMember bootstraps the caller as owner if the list has no members
-// yet (claim-on-first-invite, see list-member-repository.go), then requires
-// the caller to actually be a member - so anyone who already knows a list's
-// UUID can't invite/list-invites for a list someone else already claimed.
-func (s *ListSharingService) ensureMember(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
+// claimOrRequireMember bootstraps the caller as owner if the list has no
+// members yet (claim-on-first-invite - the only place ownership is ever
+// claimed, so merely listing or revoking invites can't grant it), then
+// requires the caller to actually be a member.
+func (s *ListSharingService) claimOrRequireMember(ctx context.Context, listID uuid.UUID, userID string, now time.Time) error {
 	if _, err := s.members.ClaimOwnershipIfUnowned(ctx, listID, userID, now); err != nil {
 		return err
 	}
+	return s.requireMember(ctx, listID, userID)
+}
 
+// requireMember checks existing membership without claiming ownership.
+func (s *ListSharingService) requireMember(ctx context.Context, listID uuid.UUID, userID string) error {
 	member, err := s.members.FindByListAndUser(ctx, listID, userID)
 	if err != nil {
 		return err
@@ -66,19 +71,18 @@ func (s *ListSharingService) requireList(listID uuid.UUID) (*entities.ToDoList, 
 	return list, nil
 }
 
-func (s *ListSharingService) CreateInvite(cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error) {
+func (s *ListSharingService) CreateInvite(ctx context.Context, cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error) {
 	ttl, err := entities.ParseInviteTTL(cmd.TTLKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %s", interfaces.ErrInvalidInviteTTL, cmd.TTLKey)
 	}
 
 	if _, err := s.requireList(cmd.ListID); err != nil {
 		return nil, err
 	}
 
-	ctx := context.Background()
 	now := time.Now().UTC()
-	if err := s.ensureMember(ctx, cmd.ListID, cmd.UserID, now); err != nil {
+	if err := s.claimOrRequireMember(ctx, cmd.ListID, cmd.UserID, now); err != nil {
 		return nil, err
 	}
 
@@ -97,18 +101,18 @@ func (s *ListSharingService) CreateInvite(cmd *command.CreateListInviteCommand) 
 	}, nil
 }
 
-func (s *ListSharingService) FindActiveInvites(qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error) {
+func (s *ListSharingService) FindActiveInvites(ctx context.Context, qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error) {
 	if _, err := s.requireList(qry.ListID); err != nil {
 		return nil, err
 	}
 
-	ctx := context.Background()
-	now := time.Now().UTC()
-	if err := s.ensureMember(ctx, qry.ListID, qry.UserID, now); err != nil {
+	// Read-only: must not claim ownership of an unowned list just because
+	// someone asked to list its invites.
+	if err := s.requireMember(ctx, qry.ListID, qry.UserID); err != nil {
 		return nil, err
 	}
 
-	invites, err := s.invites.FindActiveByList(ctx, qry.ListID, now)
+	invites, err := s.invites.FindActiveByList(ctx, qry.ListID, time.Now().UTC())
 	if err != nil {
 		return nil, err
 	}
@@ -120,9 +124,7 @@ func (s *ListSharingService) FindActiveInvites(qry *query.GetListInvitesQuery) (
 	return result, nil
 }
 
-func (s *ListSharingService) RevokeInvite(cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error) {
-	ctx := context.Background()
-
+func (s *ListSharingService) RevokeInvite(ctx context.Context, cmd *command.RevokeListInviteCommand) (*command.RevokeListInviteCommandResult, error) {
 	invite, err := s.invites.FindByID(ctx, cmd.InviteID)
 	if err != nil {
 		return nil, err
@@ -148,9 +150,7 @@ func (s *ListSharingService) RevokeInvite(cmd *command.RevokeListInviteCommand) 
 	return &command.RevokeListInviteCommandResult{}, nil
 }
 
-func (s *ListSharingService) RedeemInvite(cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error) {
-	ctx := context.Background()
-
+func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.RedeemListInviteCommand) (*command.RedeemListInviteCommandResult, error) {
 	invite, err := s.invites.FindByTokenHash(ctx, entities.HashInviteToken(cmd.Token))
 	if err != nil {
 		return nil, err

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -463,6 +463,29 @@ func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDup
 	assert.Equal(t, 1, count)
 }
 
+func TestListSharingService_RedeemInvite_RetryAfterRevokeStillSucceedsForAnExistingMember(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	first, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+	assert.False(t, first.AlreadyMember)
+
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+
+	// Bob's client retries the same redeem call (e.g. a lost response) -
+	// this must succeed as a no-op, not fail with ErrInviteRevoked, since
+	// he already has the membership the token once granted.
+	retry, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+	assert.True(t, retry.AlreadyMember)
+	assert.Equal(t, entities.RoleMember, retry.Role)
+}
+
 func TestListSharingService_RedeemInvite_RevokingAnInviteDoesNotRemoveExistingMembers(t *testing.T) {
 	list := testList()
 	svc, _, members := newSharingTestService(list)

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -211,6 +211,20 @@ func TestListSharingService_CreateInvite_NonMemberOfAlreadyClaimedListIsRejected
 	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
 }
 
+func TestListSharingService_CreateInvite_MemberMayNotInviteOthers(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	require.NoError(t, err)
+	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+
+	// bob joined as a plain member, not the owner - sharing is owner-only.
+	_, err = svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "24h"})
+	assert.ErrorIs(t, err, interfaces.ErrNotListOwner)
+}
+
 func TestListSharingService_CreateInvite_UnknownListReturnsNotFound(t *testing.T) {
 	svc, _, _ := newSharingTestService(testList())
 
@@ -303,6 +317,20 @@ func TestListSharingService_FindActiveInvites_DoesNotClaimOwnershipOfAnUnownedLi
 	assert.Nil(t, member)
 }
 
+func TestListSharingService_FindActiveInvites_MemberMayNotList(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+
+	// bob is a member, not the owner - listing invites is owner-only.
+	_, err = svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "bob"})
+	assert.ErrorIs(t, err, interfaces.ErrNotListOwner)
+}
+
 func mustTTL(t *testing.T, key string) entities.InviteTTL {
 	t.Helper()
 	ttl, err := entities.ParseInviteTTL(key)
@@ -327,27 +355,11 @@ func TestListSharingService_RevokeInvite_CreatorMayRevoke(t *testing.T) {
 	assert.NotNil(t, stored.RevokedAt)
 }
 
-func TestListSharingService_RevokeInvite_OwnerMayRevokeSomeoneElsesInvite(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-
-	// alice claims ownership as the first inviter, then bob joins as member.
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
-	require.NoError(t, err)
-	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
-	require.NoError(t, err)
-	require.NoError(t, members.Add(context.Background(), member))
-
-	bobsInvite, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "1h"})
-	require.NoError(t, err)
-
-	// alice (owner) revokes bob's invite.
-	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: bobsInvite.Result.ID, UserID: "alice"})
-	require.NoError(t, err)
-
-	// sanity: created (alice's own invite) still exists and untouched.
-	assert.NotEqual(t, created.Result.ID, bobsInvite.Result.ID)
-}
+// There used to be a test here for "the owner may revoke an invite someone
+// else created" - that scenario no longer exists now that CreateInvite is
+// itself owner-only (see TestListSharingService_CreateInvite_MemberMayNotInviteOthers):
+// the creator of any invite is always the owner, so RevokeInvite's
+// "creator OR owner" branch collapsed to "owner" (see the service).
 
 func TestListSharingService_RevokeInvite_UnrelatedMemberMayNotRevoke(t *testing.T) {
 	list := testList()

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -1,0 +1,467 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/command"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/query"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+)
+
+// fakeListInviteRepo and fakeListMemberRepo are hand-rolled in-memory
+// doubles, same rationale as fakeEventRepo in event-ingestor_test.go: this
+// backend has no mocking library, and these tests care about the service's
+// own orchestration logic, not persistence.
+type fakeListInviteRepo struct {
+	mu      sync.Mutex
+	invites map[uuid.UUID]*entities.ListInvite
+}
+
+func newFakeListInviteRepo() *fakeListInviteRepo {
+	return &fakeListInviteRepo{invites: make(map[uuid.UUID]*entities.ListInvite)}
+}
+
+func (f *fakeListInviteRepo) Create(ctx context.Context, invite *entities.ListInvite) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	stored := *invite
+	f.invites[invite.ID] = &stored
+	return nil
+}
+
+func (f *fakeListInviteRepo) FindByID(ctx context.Context, id uuid.UUID) (*entities.ListInvite, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	invite, ok := f.invites[id]
+	if !ok {
+		return nil, nil
+	}
+	stored := *invite
+	return &stored, nil
+}
+
+func (f *fakeListInviteRepo) FindByTokenHash(ctx context.Context, tokenHash string) (*entities.ListInvite, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, invite := range f.invites {
+		if invite.TokenHash == tokenHash {
+			stored := *invite
+			return &stored, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeListInviteRepo) FindActiveByList(ctx context.Context, listID uuid.UUID, now time.Time) ([]*entities.ListInvite, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var result []*entities.ListInvite
+	for _, invite := range f.invites {
+		if invite.ListID == listID && invite.IsActive(now) {
+			stored := *invite
+			result = append(result, &stored)
+		}
+	}
+	return result, nil
+}
+
+func (f *fakeListInviteRepo) Revoke(ctx context.Context, id uuid.UUID, revokedAt time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	invite, ok := f.invites[id]
+	if !ok {
+		return nil
+	}
+	invite.Revoke(revokedAt)
+	return nil
+}
+
+type memberKey struct {
+	listID uuid.UUID
+	userID string
+}
+
+type fakeListMemberRepo struct {
+	mu      sync.Mutex
+	members map[memberKey]*entities.ListMember
+}
+
+func newFakeListMemberRepo() *fakeListMemberRepo {
+	return &fakeListMemberRepo{members: make(map[memberKey]*entities.ListMember)}
+}
+
+func (f *fakeListMemberRepo) ClaimOwnershipIfUnowned(ctx context.Context, listID uuid.UUID, userID string, now time.Time) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for key := range f.members {
+		if key.listID == listID {
+			return false, nil
+		}
+	}
+	member, err := entities.NewListMember(listID, userID, entities.RoleOwner, now, nil)
+	if err != nil {
+		return false, err
+	}
+	f.members[memberKey{listID, userID}] = member
+	return true, nil
+}
+
+func (f *fakeListMemberRepo) Add(ctx context.Context, member *entities.ListMember) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := memberKey{member.ListID, member.UserID}
+	if _, exists := f.members[key]; exists {
+		return nil
+	}
+	stored := *member
+	f.members[key] = &stored
+	return nil
+}
+
+func (f *fakeListMemberRepo) FindByListAndUser(ctx context.Context, listID uuid.UUID, userID string) (*entities.ListMember, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	member, ok := f.members[memberKey{listID, userID}]
+	if !ok {
+		return nil, nil
+	}
+	stored := *member
+	return &stored, nil
+}
+
+// fakeToDoListRepo implements repositories.ToDoListRepository, but this
+// suite only ever exercises FindById - every other method panics so an
+// accidental call surfaces immediately instead of silently no-oping.
+type fakeToDoListRepo struct {
+	lists map[uuid.UUID]*entities.ToDoList
+}
+
+func newFakeToDoListRepo(lists ...*entities.ToDoList) *fakeToDoListRepo {
+	m := make(map[uuid.UUID]*entities.ToDoList, len(lists))
+	for _, l := range lists {
+		m[l.Id] = l
+	}
+	return &fakeToDoListRepo{lists: m}
+}
+
+func (f *fakeToDoListRepo) Create(*entities.ValidatedToDoList) (*entities.ToDoList, error) {
+	panic("not used by ListSharingService tests")
+}
+
+func (f *fakeToDoListRepo) FindById(id uuid.UUID) (*entities.ToDoList, error) {
+	return f.lists[id], nil
+}
+
+func (f *fakeToDoListRepo) FindAll() ([]*entities.ToDoList, error) {
+	panic("not used by ListSharingService tests")
+}
+
+func (f *fakeToDoListRepo) Update(*entities.ValidatedToDoList) (*entities.ToDoList, error) {
+	panic("not used by ListSharingService tests")
+}
+
+func (f *fakeToDoListRepo) Delete(uuid.UUID) error {
+	panic("not used by ListSharingService tests")
+}
+
+func newSharingTestService(list *entities.ToDoList) (*ListSharingService, *fakeListInviteRepo, *fakeListMemberRepo) {
+	invites := newFakeListInviteRepo()
+	members := newFakeListMemberRepo()
+	todoLists := newFakeToDoListRepo(list)
+	svc := NewListSharingService(testLogger(), invites, members, todoLists).(*ListSharingService)
+	return svc, invites, members
+}
+
+func testList() *entities.ToDoList {
+	return &entities.ToDoList{Id: uuid.New(), Name: "Rewe"}
+}
+
+// --- CreateInvite ---
+
+func TestListSharingService_CreateInvite_FirstInviterBecomesOwner(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.Token)
+
+	member, err := members.FindByListAndUser(context.Background(), list.Id, "alice")
+	require.NoError(t, err)
+	require.NotNil(t, member)
+	assert.Equal(t, entities.RoleOwner, member.Role)
+}
+
+func TestListSharingService_CreateInvite_NonMemberOfAlreadyClaimedListIsRejected(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	require.NoError(t, err)
+
+	_, err = svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "mallory", TTLKey: "24h"})
+	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
+}
+
+func TestListSharingService_CreateInvite_UnknownListReturnsNotFound(t *testing.T) {
+	svc, _, _ := newSharingTestService(testList())
+
+	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: uuid.New(), UserID: "alice", TTLKey: "24h"})
+	assert.ErrorIs(t, err, interfaces.ErrListNotFound)
+}
+
+func TestListSharingService_CreateInvite_InvalidTTLIsRejected(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "3 weeks"})
+	assert.Error(t, err)
+}
+
+func TestListSharingService_CreateInvite_ExpiresAtMatchesPresetDuration(t *testing.T) {
+	list := testList()
+	svc, invites, _ := newSharingTestService(list)
+
+	before := time.Now().UTC()
+	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	after := time.Now().UTC()
+
+	stored, err := invites.FindByID(context.Background(), result.Result.ID)
+	require.NoError(t, err)
+	assert.True(t, !stored.ExpiresAt.Before(before.Add(time.Hour)))
+	assert.True(t, !stored.ExpiresAt.After(after.Add(time.Hour)))
+}
+
+func TestListSharingService_CreateInvite_OnlyTheTokenHashIsPersisted(t *testing.T) {
+	list := testList()
+	svc, invites, _ := newSharingTestService(list)
+
+	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	stored, err := invites.FindByID(context.Background(), result.Result.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, result.Token, stored.TokenHash)
+	assert.Equal(t, entities.HashInviteToken(result.Token), stored.TokenHash)
+}
+
+func TestListSharingService_CreateInvite_TwoCallsProduceDifferentTokens(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	first, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	second, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first.Token, second.Token)
+}
+
+// --- FindActiveInvites ---
+
+func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevokedAndNeverIncludesAToken(t *testing.T) {
+	list := testList()
+	svc, invites, _ := newSharingTestService(list)
+
+	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	toRevoke, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	require.NoError(t, invites.Revoke(context.Background(), toRevoke.Result.ID, time.Now().UTC()))
+
+	// An invite that's already expired.
+	expired, _, err := entities.NewListInvite(list.Id, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, invites.Create(context.Background(), expired))
+
+	result, err := svc.FindActiveInvites(&query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
+	require.NoError(t, err)
+	require.Len(t, result.Result, 1)
+}
+
+func mustTTL(t *testing.T, key string) entities.InviteTTL {
+	t.Helper()
+	ttl, err := entities.ParseInviteTTL(key)
+	require.NoError(t, err)
+	return ttl
+}
+
+// --- RevokeInvite ---
+
+func TestListSharingService_RevokeInvite_CreatorMayRevoke(t *testing.T) {
+	list := testList()
+	svc, invites, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+
+	stored, err := invites.FindByID(context.Background(), created.Result.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, stored.RevokedAt)
+}
+
+func TestListSharingService_RevokeInvite_OwnerMayRevokeSomeoneElsesInvite(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	// alice claims ownership as the first inviter, then bob joins as member.
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
+	require.NoError(t, err)
+	require.NoError(t, members.Add(context.Background(), member))
+
+	bobsInvite, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	// alice (owner) revokes bob's invite.
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: bobsInvite.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+
+	// sanity: created (alice's own invite) still exists and untouched.
+	assert.NotEqual(t, created.Result.ID, bobsInvite.Result.ID)
+}
+
+func TestListSharingService_RevokeInvite_UnrelatedMemberMayNotRevoke(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
+	require.NoError(t, err)
+	require.NoError(t, members.Add(context.Background(), member))
+
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "bob"})
+	assert.ErrorIs(t, err, interfaces.ErrInviteNotRevocable)
+}
+
+func TestListSharingService_RevokeInvite_UnknownInviteReturnsNotFound(t *testing.T) {
+	svc, _, _ := newSharingTestService(testList())
+
+	_, err := svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: uuid.New(), UserID: "alice"})
+	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
+}
+
+func TestListSharingService_RevokeInvite_RevokingTwiceIsIdempotent(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	assert.NoError(t, err)
+}
+
+// --- RedeemInvite ---
+
+func TestListSharingService_RedeemInvite_ValidTokenGrantsMembership(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	result, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+	assert.Equal(t, list.Id, result.ListID)
+	assert.Equal(t, list.Name, result.ListName)
+	assert.Equal(t, entities.RoleMember, result.Role)
+	assert.False(t, result.AlreadyMember)
+
+	member, err := members.FindByListAndUser(context.Background(), list.Id, "bob")
+	require.NoError(t, err)
+	require.NotNil(t, member)
+	require.NotNil(t, member.InviteID)
+	assert.Equal(t, created.Result.ID, *member.InviteID)
+}
+
+func TestListSharingService_RedeemInvite_ExpiredTokenIsRejected(t *testing.T) {
+	list := testList()
+	svc, invites, _ := newSharingTestService(list)
+
+	expired, token, err := entities.NewListInvite(list.Id, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, invites.Create(context.Background(), expired))
+
+	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: string(token), UserID: "bob"})
+	assert.ErrorIs(t, err, interfaces.ErrInviteExpired)
+}
+
+func TestListSharingService_RedeemInvite_RevokedTokenIsRejected(t *testing.T) {
+	list := testList()
+	svc, _, _ := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+
+	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	assert.ErrorIs(t, err, interfaces.ErrInviteRevoked)
+}
+
+func TestListSharingService_RedeemInvite_UnknownTokenReturnsNotFound(t *testing.T) {
+	svc, _, _ := newSharingTestService(testList())
+
+	_, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: "does-not-exist", UserID: "bob"})
+	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
+}
+
+func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDuplicateMembership(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	first, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+	assert.False(t, first.AlreadyMember)
+
+	second, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+	assert.True(t, second.AlreadyMember)
+
+	count := 0
+	for key := range members.members {
+		if key.listID == list.Id && key.userID == "bob" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestListSharingService_RedeemInvite_RevokingAnInviteDoesNotRemoveExistingMembers(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	require.NoError(t, err)
+
+	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	require.NoError(t, err)
+
+	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	require.NoError(t, err)
+
+	member, err := members.FindByListAndUser(context.Background(), list.Id, "bob")
+	require.NoError(t, err)
+	assert.NotNil(t, member)
+}

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -268,7 +268,7 @@ func TestListSharingService_CreateInvite_TwoCallsProduceDifferentTokens(t *testi
 
 // --- FindActiveInvites ---
 
-func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevokedAndNeverIncludesAToken(t *testing.T) {
+func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevoked(t *testing.T) {
 	list := testList()
 	svc, invites, _ := newSharingTestService(list)
 

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -190,7 +190,7 @@ func TestListSharingService_CreateInvite_FirstInviterBecomesOwner(t *testing.T) 
 	list := testList()
 	svc, _, members := newSharingTestService(list)
 
-	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Token)
 
@@ -204,17 +204,17 @@ func TestListSharingService_CreateInvite_NonMemberOfAlreadyClaimedListIsRejected
 	list := testList()
 	svc, _, _ := newSharingTestService(list)
 
-	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
 	require.NoError(t, err)
 
-	_, err = svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "mallory", TTLKey: "24h"})
+	_, err = svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "mallory", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
 }
 
 func TestListSharingService_CreateInvite_UnknownListReturnsNotFound(t *testing.T) {
 	svc, _, _ := newSharingTestService(testList())
 
-	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: uuid.New(), UserID: "alice", TTLKey: "24h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: uuid.New(), UserID: "alice", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrListNotFound)
 }
 
@@ -222,8 +222,8 @@ func TestListSharingService_CreateInvite_InvalidTTLIsRejected(t *testing.T) {
 	list := testList()
 	svc, _, _ := newSharingTestService(list)
 
-	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "3 weeks"})
-	assert.Error(t, err)
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "3 weeks"})
+	assert.ErrorIs(t, err, interfaces.ErrInvalidInviteTTL)
 }
 
 func TestListSharingService_CreateInvite_ExpiresAtMatchesPresetDuration(t *testing.T) {
@@ -231,7 +231,7 @@ func TestListSharingService_CreateInvite_ExpiresAtMatchesPresetDuration(t *testi
 	svc, invites, _ := newSharingTestService(list)
 
 	before := time.Now().UTC()
-	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	after := time.Now().UTC()
 
@@ -245,7 +245,7 @@ func TestListSharingService_CreateInvite_OnlyTheTokenHashIsPersisted(t *testing.
 	list := testList()
 	svc, invites, _ := newSharingTestService(list)
 
-	result, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	stored, err := invites.FindByID(context.Background(), result.Result.ID)
@@ -258,9 +258,9 @@ func TestListSharingService_CreateInvite_TwoCallsProduceDifferentTokens(t *testi
 	list := testList()
 	svc, _, _ := newSharingTestService(list)
 
-	first, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	first, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
-	second, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	second, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	assert.NotEqual(t, first.Token, second.Token)
@@ -272,9 +272,9 @@ func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevokedAndNeverI
 	list := testList()
 	svc, invites, _ := newSharingTestService(list)
 
-	_, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
-	toRevoke, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	toRevoke, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	require.NoError(t, invites.Revoke(context.Background(), toRevoke.Result.ID, time.Now().UTC()))
 
@@ -283,9 +283,24 @@ func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevokedAndNeverI
 	require.NoError(t, err)
 	require.NoError(t, invites.Create(context.Background(), expired))
 
-	result, err := svc.FindActiveInvites(&query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
+	result, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
 	require.NoError(t, err)
 	require.Len(t, result.Result, 1)
+}
+
+func TestListSharingService_FindActiveInvites_DoesNotClaimOwnershipOfAnUnownedList(t *testing.T) {
+	list := testList()
+	svc, _, members := newSharingTestService(list)
+
+	// Nobody has ever created an invite for this list - it has zero
+	// members. Merely asking to list its invites must not make the caller
+	// its owner; only CreateInvite may claim ownership.
+	_, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
+	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
+
+	member, err := members.FindByListAndUser(context.Background(), list.Id, "alice")
+	require.NoError(t, err)
+	assert.Nil(t, member)
 }
 
 func mustTTL(t *testing.T, key string) entities.InviteTTL {
@@ -301,10 +316,10 @@ func TestListSharingService_RevokeInvite_CreatorMayRevoke(t *testing.T) {
 	list := testList()
 	svc, invites, _ := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
 
 	stored, err := invites.FindByID(context.Background(), created.Result.ID)
@@ -317,17 +332,17 @@ func TestListSharingService_RevokeInvite_OwnerMayRevokeSomeoneElsesInvite(t *tes
 	svc, _, members := newSharingTestService(list)
 
 	// alice claims ownership as the first inviter, then bob joins as member.
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
 	require.NoError(t, err)
 	require.NoError(t, members.Add(context.Background(), member))
 
-	bobsInvite, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "1h"})
+	bobsInvite, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	// alice (owner) revokes bob's invite.
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: bobsInvite.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: bobsInvite.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
 
 	// sanity: created (alice's own invite) still exists and untouched.
@@ -338,21 +353,21 @@ func TestListSharingService_RevokeInvite_UnrelatedMemberMayNotRevoke(t *testing.
 	list := testList()
 	svc, _, members := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
 	require.NoError(t, err)
 	require.NoError(t, members.Add(context.Background(), member))
 
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "bob"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteNotRevocable)
 }
 
 func TestListSharingService_RevokeInvite_UnknownInviteReturnsNotFound(t *testing.T) {
 	svc, _, _ := newSharingTestService(testList())
 
-	_, err := svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: uuid.New(), UserID: "alice"})
+	_, err := svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: uuid.New(), UserID: "alice"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
 }
 
@@ -360,12 +375,12 @@ func TestListSharingService_RevokeInvite_RevokingTwiceIsIdempotent(t *testing.T)
 	list := testList()
 	svc, _, _ := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	assert.NoError(t, err)
 }
 
@@ -375,10 +390,10 @@ func TestListSharingService_RedeemInvite_ValidTokenGrantsMembership(t *testing.T
 	list := testList()
 	svc, _, members := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	result, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	result, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 	assert.Equal(t, list.Id, result.ListID)
 	assert.Equal(t, list.Name, result.ListName)
@@ -400,7 +415,7 @@ func TestListSharingService_RedeemInvite_ExpiredTokenIsRejected(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, invites.Create(context.Background(), expired))
 
-	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: string(token), UserID: "bob"})
+	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: string(token), UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteExpired)
 }
 
@@ -408,19 +423,19 @@ func TestListSharingService_RedeemInvite_RevokedTokenIsRejected(t *testing.T) {
 	list := testList()
 	svc, _, _ := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
 
-	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteRevoked)
 }
 
 func TestListSharingService_RedeemInvite_UnknownTokenReturnsNotFound(t *testing.T) {
 	svc, _, _ := newSharingTestService(testList())
 
-	_, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: "does-not-exist", UserID: "bob"})
+	_, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: "does-not-exist", UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
 }
 
@@ -428,14 +443,14 @@ func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDup
 	list := testList()
 	svc, _, members := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	first, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	first, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 	assert.False(t, first.AlreadyMember)
 
-	second, err := svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	second, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 	assert.True(t, second.AlreadyMember)
 
@@ -452,13 +467,13 @@ func TestListSharingService_RedeemInvite_RevokingAnInviteDoesNotRemoveExistingMe
 	list := testList()
 	svc, _, members := newSharingTestService(list)
 
-	created, err := svc.CreateInvite(&command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	_, err = svc.RedeemInvite(&command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
+	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 
-	_, err = svc.RevokeInvite(&command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
+	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
 
 	member, err := members.FindByListAndUser(context.Background(), list.Id, "bob")

--- a/backend/internal/domain/entities/invite-token.go
+++ b/backend/internal/domain/entities/invite-token.go
@@ -1,0 +1,38 @@
+package entities
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// InviteToken is the plaintext, URL-safe secret handed to whoever redeems an
+// invite link. It exists only transiently - generated once by NewInviteToken,
+// returned to the creator, and never itself persisted; only its Hash() is
+// stored, so a database leak doesn't hand out usable invite links.
+type InviteToken string
+
+// NewInviteToken generates a 256-bit random token, base64url-encoded
+// (unpadded) so it drops straight into a URL without escaping.
+func NewInviteToken() (InviteToken, error) {
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return InviteToken(base64.RawURLEncoding.EncodeToString(raw)), nil
+}
+
+// Hash returns the token's stable, irreversible lookup key - what actually
+// gets persisted in list_invites.token_hash.
+func (t InviteToken) Hash() string {
+	return HashInviteToken(string(t))
+}
+
+// HashInviteToken hashes a raw token string presented at redeem time, so it
+// can be looked up against the stored hash without ever storing the token
+// itself.
+func HashInviteToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/domain/entities/invite-ttl.go
+++ b/backend/internal/domain/entities/invite-ttl.go
@@ -1,0 +1,34 @@
+package entities
+
+import (
+	"fmt"
+	"time"
+)
+
+// InviteTTL is one of a fixed set of validity-duration presets a client may
+// request for an invite link. Presets rather than a free-form duration so an
+// expiry can't be pushed out arbitrarily far (or into the past) by a client.
+type InviteTTL struct {
+	key      string
+	duration time.Duration
+}
+
+var inviteTTLPresets = map[string]time.Duration{
+	"1h":  time.Hour,
+	"24h": 24 * time.Hour,
+	"7d":  7 * 24 * time.Hour,
+	"30d": 30 * 24 * time.Hour,
+}
+
+// ParseInviteTTL validates key against the fixed preset list.
+func ParseInviteTTL(key string) (InviteTTL, error) {
+	duration, ok := inviteTTLPresets[key]
+	if !ok {
+		return InviteTTL{}, fmt.Errorf("invalid invite ttl %q", key)
+	}
+	return InviteTTL{key: key, duration: duration}, nil
+}
+
+func (t InviteTTL) ExpiresAt(from time.Time) time.Time {
+	return from.Add(t.duration)
+}

--- a/backend/internal/domain/entities/list-invite.go
+++ b/backend/internal/domain/entities/list-invite.go
@@ -1,0 +1,75 @@
+package entities
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ListInvite is a shareable, multi-use link granting membership on ListID to
+// whoever presents its token before it expires or gets revoked. Only
+// TokenHash is ever persisted - see InviteToken.
+type ListInvite struct {
+	ID        uuid.UUID
+	ListID    uuid.UUID
+	TokenHash string
+	CreatedBy string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	RevokedAt *time.Time
+}
+
+func (i *ListInvite) validate() error {
+	if i.ListID == uuid.Nil {
+		return errors.New("list id must not be empty")
+	}
+	if i.CreatedBy == "" {
+		return errors.New("created by must not be empty")
+	}
+	if i.TokenHash == "" {
+		return errors.New("token hash must not be empty")
+	}
+	if !i.ExpiresAt.After(i.CreatedAt) {
+		return errors.New("expires_at must be after created_at")
+	}
+	return nil
+}
+
+// NewListInvite creates a new invite for listID and returns both the invite
+// (carrying only the token's hash, safe to persist) and the plaintext token
+// (safe to hand back to createdBy exactly once, never stored).
+func NewListInvite(listID uuid.UUID, createdBy string, ttl InviteTTL, now time.Time) (*ListInvite, InviteToken, error) {
+	token, err := NewInviteToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	invite := &ListInvite{
+		ID:        uuid.New(),
+		ListID:    listID,
+		TokenHash: token.Hash(),
+		CreatedBy: createdBy,
+		CreatedAt: now,
+		ExpiresAt: ttl.ExpiresAt(now),
+	}
+	if err := invite.validate(); err != nil {
+		return nil, "", err
+	}
+	return invite, token, nil
+}
+
+// IsActive reports whether the invite can still be redeemed at now.
+func (i *ListInvite) IsActive(now time.Time) bool {
+	return i.RevokedAt == nil && i.ExpiresAt.After(now)
+}
+
+// Revoke marks the invite revoked. Revoking an already-revoked invite is a
+// no-op (idempotent) rather than an error - callers only need to reach here
+// once authorized, not track whether someone beat them to it.
+func (i *ListInvite) Revoke(now time.Time) {
+	if i.RevokedAt != nil {
+		return
+	}
+	i.RevokedAt = &now
+}

--- a/backend/internal/domain/entities/list-member.go
+++ b/backend/internal/domain/entities/list-member.go
@@ -1,0 +1,53 @@
+package entities
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type ListMemberRole string
+
+const (
+	RoleOwner  ListMemberRole = "owner"
+	RoleMember ListMemberRole = "member"
+)
+
+// ListMember is one user's membership on one list. InviteID is nil for the
+// owner created via claim-on-first-invite (there was no invite to redeem);
+// it's set for anyone who joined by redeeming a ListInvite.
+type ListMember struct {
+	ListID   uuid.UUID
+	UserID   string
+	Role     ListMemberRole
+	JoinedAt time.Time
+	InviteID *uuid.UUID
+}
+
+func (m *ListMember) validate() error {
+	if m.ListID == uuid.Nil {
+		return errors.New("list id must not be empty")
+	}
+	if m.UserID == "" {
+		return errors.New("user id must not be empty")
+	}
+	if m.Role != RoleOwner && m.Role != RoleMember {
+		return errors.New("role must be owner or member")
+	}
+	return nil
+}
+
+func NewListMember(listID uuid.UUID, userID string, role ListMemberRole, joinedAt time.Time, inviteID *uuid.UUID) (*ListMember, error) {
+	member := &ListMember{
+		ListID:   listID,
+		UserID:   userID,
+		Role:     role,
+		JoinedAt: joinedAt,
+		InviteID: inviteID,
+	}
+	if err := member.validate(); err != nil {
+		return nil, err
+	}
+	return member, nil
+}

--- a/backend/internal/domain/repositories/list-invite-repository.go
+++ b/backend/internal/domain/repositories/list-invite-repository.go
@@ -1,0 +1,22 @@
+package repositories
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+)
+
+type ListInviteRepository interface {
+	Create(ctx context.Context, invite *entities.ListInvite) error
+	FindByID(ctx context.Context, id uuid.UUID) (*entities.ListInvite, error)
+	FindByTokenHash(ctx context.Context, tokenHash string) (*entities.ListInvite, error)
+	// FindActiveByList returns invites for listID that are neither revoked
+	// nor expired as of now.
+	FindActiveByList(ctx context.Context, listID uuid.UUID, now time.Time) ([]*entities.ListInvite, error)
+	// Revoke marks the invite revoked at revokedAt. Idempotent: revoking an
+	// already-revoked invite is not an error.
+	Revoke(ctx context.Context, id uuid.UUID, revokedAt time.Time) error
+}

--- a/backend/internal/domain/repositories/list-member-repository.go
+++ b/backend/internal/domain/repositories/list-member-repository.go
@@ -1,0 +1,24 @@
+package repositories
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+)
+
+type ListMemberRepository interface {
+	// ClaimOwnershipIfUnowned atomically adds userID as owner of listID, but
+	// only if the list has no members at all yet - the bootstrap for lists
+	// that predate the sharing feature, which have no owner recorded
+	// anywhere. claimed=false means the list already had members and
+	// nothing was written.
+	ClaimOwnershipIfUnowned(ctx context.Context, listID uuid.UUID, userID string, now time.Time) (claimed bool, err error)
+	// Add inserts member. Idempotent on (list_id, user_id) - redeeming the
+	// same invite (or any invite for a list you're already on) twice must
+	// not error or duplicate the membership row.
+	Add(ctx context.Context, member *entities.ListMember) error
+	FindByListAndUser(ctx context.Context, listID uuid.UUID, userID string) (*entities.ListMember, error)
+}


### PR DESCRIPTION
## Summary

Erster von drei gestaffelten PRs für "Listen teilen" (siehe Folge-PRs für Persistenz und REST-API). Dieser PR enthält ausschließlich Domain- und Application-Layer, keine DB-Migration, keine Controller.

- Neue Entities: `InviteToken` (32-Byte-Zufallstoken, nur der sha256-Hash wird je persistiert), `InviteTTL` (feste Presets `1h`/`24h`/`7d`/`30d`), `ListInvite`, `ListMember` (Rollen `owner`/`member`).
- Neue Repository-Interfaces `ListInviteRepository`, `ListMemberRepository` (ctx-first, im Stil von `EventRepository`).
- `ListSharingService` mit `CreateInvite` / `FindActiveInvites` / `RevokeInvite` / `RedeemInvite`:
  - **Claim-on-first-invite:** die erste Person, die für eine Liste einlädt, wird automatisch `owner` — löst das Bootstrap-Problem für Bestandslisten ohne Migration.
  - Widerrufen darf der Ersteller der Einladung oder ein `owner`.
  - Redeem ist idempotent (bereits Mitglied → Erfolg statt Fehler) und liefert den Listennamen mit zurück, damit der Client die Liste lokal anlegen kann.
- Unit-Tests mit handgeschriebenen In-Memory-Fakes (kein Mocking-Framework, wie der Rest des Backends), kein Docker nötig.

**Bewusst außerhalb dieses Scopes:** Membership wird auf `/api/v1/events` und `/api/v1/sync/*` noch **nicht** durchgesetzt — jede gültige Keycloak-Session darf weiterhin jede bekannte Listen-UUID lesen/schreiben, wie schon heute. Das ist ein eigener, sorgfältig zu staffelnder Folge-PR.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/domain/... ./internal/application/...` — alle grün, kein Docker nötig
- [ ] Review der claim-on-first-invite-Semantik und der Revoke-Berechtigung (Ersteller ODER Owner)