### PR TITLE
fix(backend): FindById returns nil instead of pgx.ErrNoRows for missing lists

### DIFF
--- a/backend/internal/infrastructure/db/postgres/sqlc_todo-list-repository.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_todo-list-repository.go
@@ -2,8 +2,10 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
@@ -40,6 +42,12 @@ func (repo *SqlcToDoListRepository) FindById(id uuid.UUID) (*entities.ToDoList, 
 
 	row, err := repo.queries.GetToDoListById(ctx, id)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Not found (or soft-deleted - GetToDoListById filters
+			// deleted_at) is a nil result, not an error: callers
+			// distinguish "missing" from "query failed" by the nil check.
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/backend/internal/infrastructure/db/postgres/sqlc_todo-list-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_todo-list-repository_test.go
@@ -1,0 +1,81 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
+)
+
+func TestSqlcToDoListRepository_FindById_UnknownIdReturnsNilWithoutError(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcToDoListRepository(NewQueries(testDB.Conn))
+
+	found, err := repo.FindById(uuid.New())
+
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+func TestSqlcToDoListRepository_FindById_ExistingListRoundtrips(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcToDoListRepository(NewQueries(testDB.Conn))
+
+	toDoList := entities.NewToDoList(uuid.New(), "Rewe")
+	validated, err := entities.NewValidatedToDoList(toDoList)
+	require.NoError(t, err)
+	_, err = repo.Create(validated)
+	require.NoError(t, err)
+
+	found, err := repo.FindById(toDoList.Id)
+
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, toDoList.Id, found.Id)
+	assert.Equal(t, "Rewe", found.Name)
+}
+
+func TestSqlcToDoListRepository_FindById_SoftDeletedListReturnsNilWithoutError(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcToDoListRepository(NewQueries(testDB.Conn))
+
+	toDoList := entities.NewToDoList(uuid.New(), "Rewe")
+	validated, err := entities.NewValidatedToDoList(toDoList)
+	require.NoError(t, err)
+	_, err = repo.Create(validated)
+	require.NoError(t, err)
+	require.NoError(t, repo.Delete(toDoList.Id))
+
+	found, err := repo.FindById(toDoList.Id)
+
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+// TestSqlcToDoListRepository_Update_OfAnUnknownListDoesNotPanic guards the
+// call chain Update -> FindById (see sqlc_todo-list-repository.go) now that
+// FindById can return (nil, nil): Update itself doesn't check for a missing
+// row (UpdateToDoList's UPDATE matches zero rows silently), so it must not
+// panic dereferencing a nil result.
+func TestSqlcToDoListRepository_Update_OfAnUnknownListDoesNotPanic(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcToDoListRepository(NewQueries(testDB.Conn))
+
+	toDoList := entities.NewToDoList(uuid.New(), "Rewe")
+	require.NoError(t, toDoList.UpdateName("Aldi"))
+	validated, err := entities.NewValidatedToDoList(toDoList)
+	require.NoError(t, err)
+
+	found, err := repo.Update(validated)
+
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}


### PR DESCRIPTION
## Summary

Kleiner, in sich abgeschlossener Bugfix, unabhängig vom Sharing-Feature (gefunden während der Arbeit an #222).

- `SqlcToDoListRepository.FindById` reichte `pgx.ErrNoRows` bei einer unbekannten oder soft-gelöschten Liste roh durch, statt `(nil, nil)` zurückzugeben.
- Dadurch waren die `existingToDoList == nil`-Checks in `ToDoListService.UpdateToDoList`/`DeleteToDoList` toter Code: eine unbekannte Liste erzeugte einen rohen Postgres-Fehler statt der eigentlich vorgesehenen `"todo list not found"`-Fehlermeldung.
- Fix folgt demselben Muster, das `SqlcEventRepository` bereits für `pgx.ErrNoRows` verwendet.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .`
- [x] Neue Tests in `sqlc_todo-list-repository_test.go` (Testcontainer): unbekannte ID → `(nil, nil)`; soft-gelöschte Liste → `(nil, nil)`; normaler Roundtrip; `Update` einer unbekannten Liste läuft ohne Panic durch
- [x] `go test ./...` komplett grün