### PR TITLE
fix(frontend): serialize ack processing to preserve seq order

### DIFF
--- a/frontend/api/sync/__tests__/sync-engine.test.ts
+++ b/frontend/api/sync/__tests__/sync-engine.test.ts
@@ -315,6 +315,71 @@ describe("SyncEngine", () => {
       expect(events.markSeq).not.toHaveBeenCalled()
       expect(applier.rebuildForAck).not.toHaveBeenCalled()
     })
+
+    it("processes acks for the same list one at a time, in call order, even if an earlier ack's own lookup resolves slower than a later ack's", async () => {
+      // Reproduces the bug this queue prevents: SyncSocket dispatches each
+      // "ack" message via a synchronous, unawaited callback, so without
+      // serialization a later-arriving ack whose dependencies happen to
+      // resolve faster could finish (and rebuild) before an
+      // earlier-arriving one - e.g. todo_list.sync_enabled's rebuild
+      // running while todo_list.created is still locally unconfirmed.
+      const callOrder: string[] = []
+
+      let resolveCreatedLookup: (
+        value: Result<DomainEventRow[], DbQueryError>
+      ) => void
+      const createdLookup = new Promise<Result<DomainEventRow[], DbQueryError>>(
+        (resolve) => {
+          resolveCreatedLookup = resolve
+        }
+      )
+
+      events.getByEventIds.mockImplementation(([eventId]: string[]) => {
+        if (eventId === "created-1") {
+          return createdLookup
+        }
+        return Promise.resolve(
+          Result.ok([
+            makeEvent({
+              event_id: "sync-enabled-1",
+              list_id: "list-1",
+              seq: null,
+            }),
+          ])
+        )
+      })
+      events.markSeq.mockImplementation((eventId: string) => {
+        callOrder.push(`markSeq:${eventId}`)
+        return Promise.resolve(Result.ok(undefined))
+      })
+      applier.rebuildForAck.mockImplementation((listId: string) => {
+        callOrder.push(`rebuild:${listId}`)
+        return Promise.resolve(Result.ok(undefined))
+      })
+
+      // Fired without awaiting the first, matching how SyncSocket actually
+      // dispatches two incoming ack messages.
+      const firstAck = engine.handleAck("created-1", 58)
+      const secondAck = engine.handleAck("sync-enabled-1", 59)
+
+      // Give the second ack every chance to race ahead before the first
+      // ack's blocked lookup is released.
+      await flushMicrotasks()
+      resolveCreatedLookup!(
+        Result.ok([
+          makeEvent({ event_id: "created-1", list_id: "list-1", seq: null }),
+        ])
+      )
+
+      await Promise.all([firstAck, secondAck])
+
+      expect(callOrder).toEqual([
+        "markSeq:created-1",
+        "rebuild:list-1",
+        "markSeq:sync-enabled-1",
+        "rebuild:list-1",
+      ])
+    })
   })
 
   describe("reconcile", () => {

--- a/frontend/api/sync/sync-engine.ts
+++ b/frontend/api/sync/sync-engine.ts
@@ -36,6 +36,13 @@ export const MAX_DRAIN_BATCHES = 20
 export class SyncEngine {
   private readonly inFlight = new Set<string>()
   private flushing = false
+  // Serializes handleAck() end-to-end - see its doc comment for why two
+  // acks for the same list must never process concurrently. Deliberately a
+  // separate queue from write-lock.ts's runExclusive: handleAckOrdered's
+  // own steps (markSynced, markSeq, rebuildForAck) already funnel through
+  // that queue internally, and nesting the same queue inside itself here
+  // would deadlock (see EventApplier's class doc for the same hazard).
+  private ackQueue: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly outboxRepository: OutboxRepository,
@@ -139,8 +146,28 @@ export class SyncEngine {
    * position `seq`. Marks the outbox row synced and, for a first-time ack,
    * records the seq and rebuilds the affected list (byServerSeqThenLocal).
    * See sync-design-decisions.md ("Ack trägt seq mit").
+   *
+   * Queued onto ackQueue rather than run directly: SyncSocket dispatches
+   * each "ack" message via a synchronous, unawaited callback, so two acks
+   * for the same list could otherwise finish processing in whichever order
+   * their own awaits happen to resolve, not necessarily arrival order -
+   * letting byServerSeqThenLocal sort a later-seq event before an
+   * earlier-seq one that's still locally unconfirmed (e.g. replaying
+   * todo_list.sync_enabled before todo_list.created no-ops the UPDATE, and
+   * the following handleCreated INSERT re-creates the row with the
+   * column's default). Queuing guarantees each ack's write+rebuild fully
+   * completes, in arrival order, before the next one starts.
    */
   async handleAck(eventId: string, seq: number): Promise<void> {
+    const run = this.ackQueue.then(() => this.handleAckOrdered(eventId, seq))
+    this.ackQueue = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  private async handleAckOrdered(eventId: string, seq: number): Promise<void> {
     const result = await this.outboxRepository.markSynced(eventId)
     if (!result.success) {
       logger.error(


### PR DESCRIPTION
## Summary

- Fixes a real bug found live: a list toggled to sync-on (via the context menu, on an existing list) durably lost its `sync_enabled` flag after the app restarted, even though the enabling event was present in the local event log and both it and the list's `todo_list.created` event were confirmed processed on the backend (verified via direct DB inspection - seq 58 for `created`, seq 59 for `sync_enabled`, correct order server-side).
- Root cause: `SyncSocket` dispatches each incoming WebSocket `ack` message via a synchronous, unawaited callback (`sync-socket.ts:225`), so two acks for the same list previously ran as independent, concurrent `SyncEngine.handleAck` calls. Whichever one *finished* its own internal steps first won, not whichever *arrived* first - even though the backend guarantees arrival order matches true seq order (single, strictly-FIFO ingestor).
- If a later-seq ack's rebuild ran while an earlier-seq event (e.g. `todo_list.created`) was still locally unconfirmed, `byServerSeqThenLocal` sorted the confirmed-but-later event first anyway. Replaying `todo_list.sync_enabled` before `todo_list.created` silently no-ops the `UPDATE` (the row doesn't exist yet), and the following `handleCreated` `INSERT` re-creates the row with `sync_enabled` back at its column default (`0`) - durably losing the flag. Nothing self-heals this afterward: `reconcile` only recovers events the server is missing, not a seq the client failed to record for one it already has.
- Confirmed this only affects the "toggle sync on for an *existing* list" path: creating a list with sync on from the start only ever pushes/acks a single event (`todo_list.created`); its own `todo_list.sync_enabled` event is deliberately never sent to the backend, so there's no second ack to race against.

## Fix

`SyncEngine.handleAck` now queues onto a dedicated `ackQueue` (same small serial-queue pattern as `database/write-lock.ts`'s `runExclusive`, kept separate since `handleAck`'s own steps already funnel through that queue internally - nesting the same queue would deadlock). Each ack's write + rebuild now fully completes, in arrival order, before the next one starts.

## Test plan

- [x] New regression test in `sync-engine.test.ts` reproduces the exact race (two concurrent acks for the same list, later one's dependencies resolving first) and asserts correct call ordering. Verified it fails without the fix (reverted the fix locally, confirmed the test catches the bug) and passes with it.
- [x] `npx jest --no-watchman` - all 442 tests pass.
- [x] `npx tsc --noEmit`, `npx eslint` on changed files - clean.
- [x] Verified live on-device: this is the actual bug report that led to the fix - toggled sync on for an existing list with the fix applied, restarted the app, flag stuck correctly. Lists toggled before the fix was applied stay durably corrupted (see PR description above) since the fix only prevents the race going forward; not repaired here, dev data only.
