### PR TITLE
fix(backend): don't retry permanently undeliverable events forever

### DIFF
--- a/backend/internal/application/interfaces/permanent-error.go
+++ b/backend/internal/application/interfaces/permanent-error.go
@@ -1,0 +1,21 @@
+package interfaces
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrPermanent marks a dispatch failure as unfixable by retrying - a bad
+// payload or a validation failure will fail exactly the same way on the
+// millionth attempt as on the first. EventDispatcher's caller
+// (EventIngestor.dispatchAndAck) uses errors.Is against this sentinel to
+// tell such an error apart from a transient one (e.g. a DB connection
+// blip), which must still be left unprocessed for a retry.
+var ErrPermanent = errors.New("permanent error")
+
+// Permanent wraps err so errors.Is(wrapped, ErrPermanent) succeeds while
+// errors.Is/As against err's own type still works - callers that only care
+// about "was this retryable" don't need to know the concrete cause.
+func Permanent(err error) error {
+	return fmt.Errorf("%w: %w", ErrPermanent, err)
+}

--- a/backend/internal/application/services/create-todo-list-event-handler.go
+++ b/backend/internal/application/services/create-todo-list-event-handler.go
@@ -25,7 +25,9 @@ func (h *CreateToDoListEventHandler) EventType() string {
 func (h *CreateToDoListEventHandler) Handle(ctx context.Context, storedEvent *repositories.StoredEvent) error {
 	var event events.CreateToDoListEvent
 	if err := json.Unmarshal(storedEvent.Payload, &event); err != nil {
-		return err
+		// Malformed payload will fail to unmarshal on every retry - not a
+		// transient failure, see interfaces.ErrPermanent.
+		return interfaces.Permanent(err)
 	}
 
 	_, err := h.service.CreateToDoList(ctx, &command.CreateToDoListCommand{

--- a/backend/internal/application/services/event-ingestor.go
+++ b/backend/internal/application/services/event-ingestor.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 
@@ -142,14 +143,23 @@ func (ing *EventIngestor) process(ctx context.Context, event *repositories.Store
 func (ing *EventIngestor) dispatchAndAck(ctx context.Context, event *repositories.StoredEvent) {
 	// Dispatch silently no-ops for unknown event types (forward
 	// compatibility, see EventDispatcher) - that still counts as "durably
-	// received", so it's still marked processed and acked. Only handled
-	// types that error should stay unprocessed for a retry.
+	// received", so it's still marked processed and acked. A handler error
+	// wrapped in interfaces.ErrPermanent (bad payload, failed validation) is
+	// unfixable by retrying and gets the same treatment - only an
+	// unwrapped, presumably transient error (e.g. a DB blip) is left
+	// unprocessed for sweepUnprocessed to retry.
 	if err := ing.dispatcher.Dispatch(ctx, event); err != nil {
+		if !errors.Is(err, interfaces.ErrPermanent) {
+			ing.logger.Error(
+				"failed to dispatch event",
+				"event_id", event.EventID, "event_type", event.EventType, "error", err,
+			)
+			return
+		}
 		ing.logger.Error(
-			"failed to dispatch event",
+			"event permanently undeliverable, recording it without applying it",
 			"event_id", event.EventID, "event_type", event.EventType, "error", err,
 		)
-		return
 	}
 	seq, listID, err := ing.eventRepo.MarkProcessed(ctx, event.EventID)
 	if err != nil {

--- a/backend/internal/application/services/event-ingestor_test.go
+++ b/backend/internal/application/services/event-ingestor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/interfaces"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
 )
 
@@ -365,9 +366,13 @@ func TestEventIngestor_DuplicateEventID_AcksWithoutRedispatching(t *testing.T) {
 	assert.Equal(t, ack.seqOf(event.EventID), int64(1))
 }
 
+// TestEventIngestor_DispatchFailure_NoAckAndNotMarkedProcessed covers a
+// transient dispatch error (a plain, unwrapped error - e.g. a DB connection
+// blip) - it must stay unprocessed and unacked so sweepUnprocessed retries
+// it, unlike a permanent error (see the Permanent_ tests below).
 func TestEventIngestor_DispatchFailure_NoAckAndNotMarkedProcessed(t *testing.T) {
 	repo := newFakeEventRepo()
-	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("todo list not found")}
+	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("connection reset by peer")}
 	dispatcher := NewEventDispatcher(testLogger(), handler)
 	ack := &fakeAckPublisher{}
 	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
@@ -397,7 +402,7 @@ func TestEventIngestor_DispatchFailure_LogsWithEventContext(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
 	repo := newFakeEventRepo()
-	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("todo list not found")}
+	handler := &fakeHandler{eventType: "todo_list.updated", err: errors.New("connection reset by peer")}
 	dispatcher := NewEventDispatcher(logger, handler)
 	ack := &fakeAckPublisher{}
 	ingestor := NewEventIngestor(logger, repo, dispatcher, ack)
@@ -417,7 +422,63 @@ func TestEventIngestor_DispatchFailure_LogsWithEventContext(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 	assert.Equal(t, "ERROR", decoded["level"])
 	assert.Equal(t, event.EventID.String(), decoded["event_id"])
-	assert.Contains(t, decoded["error"], "todo list not found")
+	assert.Contains(t, decoded["error"], "connection reset by peer")
+}
+
+// TestEventIngestor_PermanentDispatchFailure_MarkedProcessedAndAcked is the
+// counterpart to the transient case above: a handler error wrapped in
+// interfaces.ErrPermanent (bad payload, failed validation - unfixable by
+// retrying) must be treated like the unknown-event-type no-op path -
+// recorded and acked, not left to poison sweepUnprocessed forever.
+func TestEventIngestor_PermanentDispatchFailure_MarkedProcessedAndAcked(t *testing.T) {
+	repo := newFakeEventRepo()
+	handler := &fakeHandler{eventType: "todo_list.updated", err: interfaces.Permanent(errors.New("name must not be empty"))}
+	dispatcher := NewEventDispatcher(testLogger(), handler)
+	ack := &fakeAckPublisher{}
+	ingestor := NewEventIngestor(testLogger(), repo, dispatcher, ack)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingestor.Start(ctx)
+	defer ingestor.Stop()
+
+	event := makeIngestorTestEvent("todo_list.updated")
+	require.NoError(t, ingestor.Enqueue(ctx, event))
+
+	require.Eventually(t, func() bool { return ack.has(event.EventID) }, time.Second, time.Millisecond)
+	assert.True(t, repo.isProcessed(event.EventID))
+	assert.Equal(t, 1, handler.callCount())
+}
+
+// TestEventIngestor_PermanentDispatchFailure_LogsWithEventContext mirrors
+// TestEventIngestor_DispatchFailure_LogsWithEventContext for the permanent
+// path - silently swallowing an unprocessable event would be as bad as
+// looping on it forever.
+func TestEventIngestor_PermanentDispatchFailure_LogsWithEventContext(t *testing.T) {
+	var buf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	repo := newFakeEventRepo()
+	handler := &fakeHandler{eventType: "todo_list.updated", err: interfaces.Permanent(errors.New("name must not be empty"))}
+	dispatcher := NewEventDispatcher(logger, handler)
+	ack := &fakeAckPublisher{}
+	ingestor := NewEventIngestor(logger, repo, dispatcher, ack)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingestor.Start(ctx)
+	defer ingestor.Stop()
+
+	event := makeIngestorTestEvent("todo_list.updated")
+	require.NoError(t, ingestor.Enqueue(ctx, event))
+	require.Eventually(t, func() bool { return ack.has(event.EventID) }, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return buf.Len() > 0 }, time.Second, time.Millisecond)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	assert.Equal(t, "ERROR", decoded["level"])
+	assert.Equal(t, event.EventID.String(), decoded["event_id"])
+	assert.Contains(t, decoded["error"], "name must not be empty")
 }
 
 func TestEventIngestor_UnknownEventType_StillAckedForwardCompatibly(t *testing.T) {

--- a/backend/internal/application/services/todo-list-service.go
+++ b/backend/internal/application/services/todo-list-service.go
@@ -27,7 +27,11 @@ func (s *ToDoListService) CreateToDoList(ctx context.Context, todoListCommand *c
 
 	validatedToDoList, err := entities.NewValidatedToDoList(newToDoList)
 	if err != nil {
-		return nil, err
+		// A validation failure (e.g. empty name) will fail identically on
+		// every retry - not a transient failure, see interfaces.ErrPermanent.
+		// Only this error is wrapped; a repository error below is left as-is
+		// since it may well be transient (e.g. a DB connection blip).
+		return nil, interfaces.Permanent(err)
 	}
 
 	if err := s.todoListRepository.Create(ctx, validatedToDoList); err != nil {
@@ -52,7 +56,8 @@ func (s *ToDoListService) UpdateToDoList(ctx context.Context, todoListCommand *c
 
 	validatedToDoList, err := entities.NewValidatedToDoList(toDoList)
 	if err != nil {
-		return nil, err
+		// See the identical comment in CreateToDoList.
+		return nil, interfaces.Permanent(err)
 	}
 
 	if err := s.todoListRepository.Update(ctx, validatedToDoList); err != nil {

--- a/backend/internal/application/services/todo-list-service_test.go
+++ b/backend/internal/application/services/todo-list-service_test.go
@@ -220,3 +220,120 @@ func TestEventIngestor_ToDoListUpdated_ForUnknownList_IsMarkedProcessedAndAcked(
 	require.Eventually(t, func() bool { return ack.has(event.EventID) }, time.Second, time.Millisecond)
 	assert.True(t, eventRepo.isProcessed(event.EventID))
 }
+
+// TestToDoListService_CreateAndUpdate_EmptyNameIsAPermanentError asserts
+// that the one error CreateToDoList/UpdateToDoList can return today - a
+// validation failure from entities.NewValidatedToDoList - is wrapped in
+// interfaces.ErrPermanent, since retrying an empty-name event can never
+// succeed. A repository-layer error is deliberately not covered here: it's
+// left unwrapped because it may well be transient (e.g. a DB blip).
+func TestToDoListService_CreateAndUpdate_EmptyNameIsAPermanentError(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	service := newTestToDoListService(testDB)
+	ctx := context.Background()
+	listID := uuid.New()
+	now := time.Now().UTC()
+
+	_, err := service.CreateToDoList(ctx, &command.CreateToDoListCommand{Id: listID, Name: "", OccurredAt: now})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrPermanent)
+
+	_, err = service.UpdateToDoList(ctx, &command.UpdateToDoListCommand{Id: listID, Name: "", OccurredAt: now})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, interfaces.ErrPermanent)
+}
+
+// TestEventIngestor_ToDoListCreated_EmptyName_IsMarkedProcessedAndAcked is
+// the end-to-end regression test for a permanently undeliverable event
+// reaching the real service/handler stack (not the fakeHandler used
+// elsewhere): a todo_list.created with an empty name must not poison the
+// queue the same way an unknown list id used to before this fix - it's
+// recorded and acked, not retried forever.
+func TestEventIngestor_ToDoListCreated_EmptyName_IsMarkedProcessedAndAcked(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+
+	service := newTestToDoListService(testDB)
+	repo := postgres.NewSqlcToDoListRepository(postgres.NewQueries(testDB.Conn))
+	dispatcher := NewEventDispatcher(testLogger(),
+		NewCreateToDoListEventHandler(service),
+		NewUpdateToDoListEventHandler(service),
+		NewDeleteToDoListEventHandler(service),
+	)
+	eventRepo := newFakeEventRepo()
+	ack := &fakeAckPublisher{}
+	ingestor := NewEventIngestor(testLogger(), eventRepo, dispatcher, ack)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingestor.Start(ctx)
+	defer ingestor.Stop()
+
+	listID := uuid.New()
+	payload, err := json.Marshal(events.CreateToDoListEvent{Name: ""})
+	require.NoError(t, err)
+	event := &repositories.StoredEvent{
+		EventID:       uuid.New(),
+		EventType:     events.EventTypeCreateToDoList,
+		AggregateID:   listID,
+		AggregateType: "todo_list",
+		ListID:        &listID,
+		Payload:       payload,
+		OccurredAt:    time.Now().UTC(),
+		ClientID:      "client-1",
+	}
+
+	require.NoError(t, ingestor.Enqueue(ctx, event))
+
+	require.Eventually(t, func() bool { return ack.has(event.EventID) }, time.Second, time.Millisecond)
+	assert.True(t, eventRepo.isProcessed(event.EventID))
+
+	// The permanent error means the list was never actually created either -
+	// only the event's fate (processed, acked) changed, not CreateToDoList's
+	// own no-op-on-failure behavior.
+	found, err := repo.FindById(ctx, listID)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+// TestEventIngestor_ToDoListCreated_MalformedPayload_IsMarkedProcessedAndAcked
+// is the same regression, triggered by the other permanent-error source:
+// json.Unmarshal failing on a payload that isn't valid JSON for the event
+// type at all (as opposed to valid JSON with an invalid field value).
+func TestEventIngestor_ToDoListCreated_MalformedPayload_IsMarkedProcessedAndAcked(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+
+	service := newTestToDoListService(testDB)
+	dispatcher := NewEventDispatcher(testLogger(),
+		NewCreateToDoListEventHandler(service),
+		NewUpdateToDoListEventHandler(service),
+		NewDeleteToDoListEventHandler(service),
+	)
+	eventRepo := newFakeEventRepo()
+	ack := &fakeAckPublisher{}
+	ingestor := NewEventIngestor(testLogger(), eventRepo, dispatcher, ack)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ingestor.Start(ctx)
+	defer ingestor.Stop()
+
+	listID := uuid.New()
+	event := &repositories.StoredEvent{
+		EventID:       uuid.New(),
+		EventType:     events.EventTypeCreateToDoList,
+		AggregateID:   listID,
+		AggregateType: "todo_list",
+		ListID:        &listID,
+		Payload:       json.RawMessage(`{"name": `), // truncated - not valid JSON
+		OccurredAt:    time.Now().UTC(),
+		ClientID:      "client-1",
+	}
+
+	require.NoError(t, ingestor.Enqueue(ctx, event))
+
+	require.Eventually(t, func() bool { return ack.has(event.EventID) }, time.Second, time.Millisecond)
+	assert.True(t, eventRepo.isProcessed(event.EventID))
+}

--- a/backend/internal/application/services/update-todo-list-event-handler.go
+++ b/backend/internal/application/services/update-todo-list-event-handler.go
@@ -25,7 +25,9 @@ func (h *UpdateToDoListEventHandler) EventType() string {
 func (h *UpdateToDoListEventHandler) Handle(ctx context.Context, storedEvent *repositories.StoredEvent) error {
 	var event events.UpdateToDoListEvent
 	if err := json.Unmarshal(storedEvent.Payload, &event); err != nil {
-		return err
+		// Malformed payload will fail to unmarshal on every retry - not a
+		// transient failure, see interfaces.ErrPermanent.
+		return interfaces.Permanent(err)
 	}
 
 	_, err := h.service.UpdateToDoList(ctx, &command.UpdateToDoListCommand{

--- a/frontend/docs/sync-sharing-target.md
+++ b/frontend/docs/sync-sharing-target.md
@@ -178,12 +178,15 @@ zweifacher Vorwärts-Anwendung derselben Event-Folge (`TestToDoListService_Forwa
 
 **6.8 Jedes durabel angenommene Event bekommt genau einmal ein seq.** `GetEventsSince`, `GetListHeads`
 und `GetKnownEventIdsByList` filtern alle `seq IS NOT NULL` — ein Event, dessen Handler dauerhaft
-fehlschlägt (heute z. B. `UpdateToDoList`/`DeleteToDoList` mit leerem Namen, siehe `validate()` in
-`entities/todo-list.go`), bekommt nie ein `seq` und ist damit für Pull *und* Reconcile unsichtbar.
-`dispatchAndAck` überspringt in diesem Fall auch `MarkProcessed` und den Ack (siehe `event-ingestor.go`),
-der Client resendet also unbegrenzt, ohne dass der Server je „fertig" meldet. Das ist derselbe
-Mechanismus, den `b81caa1`/`3821b45` für „Zeile nicht gefunden" bereits behoben haben — für dauerhafte
-Handler-Fehler (kaputtes Payload, leerer Name) steht die gleichwertige Behebung noch aus.
+fehlschlägt (z. B. `CreateToDoList`/`UpdateToDoList` mit leerem Namen, siehe `validate()` in
+`entities/todo-list.go`, oder ein Payload, an dem `json.Unmarshal` scheitert), bekommt sonst nie ein
+`seq` und ist damit für Pull *und* Reconcile unsichtbar, während `dispatchAndAck` `MarkProcessed` und
+den Ack überspringt (siehe `event-ingestor.go`) — der Client resendet unbegrenzt, ohne dass der
+Server je „fertig" meldet. Das ist derselbe Mechanismus, den `b81caa1`/`3821b45` für „Zeile nicht
+gefunden" behoben haben; für dauerhafte Handler-Fehler (kaputtes Payload, leerer Name) übernimmt das
+`interfaces.ErrPermanent`/`interfaces.Permanent(err)` (`permanent-error.go`): ein so markierter Fehler
+wird in `dispatchAndAck` wie der Unknown-Event-Type-Pfad behandelt — `MarkProcessed` + Ack, statt
+unprocessed liegen zu bleiben.
 
 ## 7. Offene Entscheidungen
 


### PR DESCRIPTION
## Summary

- **Permanent vs. transient errors.** `EventIngestor.dispatchAndAck` treated every handler error as retryable — it skipped both `MarkProcessed` and the ack, so `sweepUnprocessed` kept retrying on every restart and the client, never acked, resent indefinitely. #244 fixed this for one cause (an unknown/deleted `todo_lists` row). Two more permanent causes have the exact same symptom: an empty-name `create`/`update` failing `entities.validate()`, and a payload that fails `json.Unmarshal` in the handler. Both fail identically no matter how many times they're retried.
- **`ErrPermanent` sentinel.** Introduces `interfaces.ErrPermanent` / `interfaces.Permanent(err)`, the same sentinel-error shape already used by `ListSharingService`. The two event handlers wrap their unmarshal failures with it; `ToDoListService` wraps only the validation failure from `NewValidatedToDoList`, not a repository error, which may still be transient.
- **`dispatchAndAck` handling.** Now treats a permanent error like the existing unknown-event-type no-op path: `MarkProcessed` + ack, instead of leaving it stuck. Applies to both live processing and `sweepUnprocessed`, so already-stuck rows from before this fix get cleared on next restart too.
- **`seq` visibility.** Folds in the `seq`-visibility consequence noted while reviewing #244: an event that never gets marked processed never gets a `seq` either, so it's invisible to pull and reconcile too (`seq IS NOT NULL` is the filter both use), not just an unprocessed row. Recorded as invariant 6.8 in `sync-sharing-target.md`, now updated to reflect this fix.

Originally stacked on #244 (now merged into `main`); this PR was reopened against `main` directly after GitHub closed the stacked version when the parent branch was deleted on merge.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (testcontainers, Docker required) — all green, including:
  - `event-ingestor_test.go`: a permanent dispatch error is marked processed and acked (fake handler); the existing transient-error test still passes unprocessed/unacked
  - `todo-list-service_test.go`: end-to-end through the real handler stack — an empty-name `created` and a malformed-JSON payload are both marked processed and acked, without ever materializing a row
- [x] Negative control: temporarily reverted the `dispatchAndAck` change and confirmed all four new tests fail (not tautological), then restored it
