### PR TITLE
fix(frontend): make list/ingredient projections total, never throw on a bad event

### DIFF
--- a/frontend/api/sync/__tests__/event-applier.test.ts
+++ b/frontend/api/sync/__tests__/event-applier.test.ts
@@ -297,6 +297,71 @@ describe("EventApplier", () => {
     expect(notifySyncListsChanged).not.toHaveBeenCalled()
   })
 
+  // Poison-pill regression: a corrupt payload used to throw out of the
+  // projection rebuild, out of this transaction, and get caught by apply()
+  // as a failure - leaving the cursor stuck so the next pull re-fetched the
+  // same corrupt page forever. With total projections, the bad event is
+  // just skipped: apply() still succeeds, the cursor still advances, and
+  // every other event in the page (and the next page) still applies.
+  it("doesn't abort on a corrupt payload mid-page - the rest of the page still applies and the cursor advances", async () => {
+    const corruptIngredient = makeIngredientCreated({
+      event_id: "ing-corrupt",
+      aggregate_id: "ing-bad",
+      occurred_at: 1500,
+      payload: "{not valid json",
+    })
+
+    const result = await applier.apply(
+      "list-1",
+      [makeEvent(), corruptIngredient, makeIngredientCreated()],
+      5
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.getValue()).toEqual({ applied: 3 })
+
+    const list = await db.getFirstAsync<{ name: string }>(
+      `SELECT name FROM ingredient_lists WHERE id = 'list-1'`
+    )
+    expect(list?.name).toBe("Rewe")
+
+    const goodIngredient = await db.getFirstAsync<{ name: string }>(
+      `SELECT name FROM ingredients WHERE id = 'ing-1'`
+    )
+    expect(goodIngredient?.name).toBe("Milk")
+
+    const badIngredient = await db.getFirstAsync(
+      `SELECT id FROM ingredients WHERE id = 'ing-bad'`
+    )
+    expect(badIngredient).toBeNull()
+
+    const cursorRow = await db.getFirstAsync<{ last_seen_seq: number }>(
+      `SELECT last_seen_seq FROM sync_cursors WHERE list_id = 'list-1'`
+    )
+    expect(cursorRow?.last_seen_seq).toBe(5)
+
+    // The next pull for this list must not be stuck repeating the same
+    // page - a fresh page applies cleanly and the cursor keeps advancing.
+    const followUp = await applier.apply(
+      "list-1",
+      [
+        makeEvent({
+          event_id: "e-followup",
+          event_type: EventTypes.TODO_LIST_UPDATED,
+          occurred_at: 2000,
+          payload: JSON.stringify({ name: "Lidl" }),
+        }),
+      ],
+      9
+    )
+    expect(followUp.success).toBe(true)
+
+    const cursorAfterFollowUp = await db.getFirstAsync<{
+      last_seen_seq: number
+    }>(`SELECT last_seen_seq FROM sync_cursors WHERE list_id = 'list-1'`)
+    expect(cursorAfterFollowUp?.last_seen_seq).toBe(9)
+  })
+
   it("is atomic: a failure partway through rolls back the event inserts, projections, and cursor together", async () => {
     jest
       .spyOn(cursorRepository, "setWithin")

--- a/frontend/database/__tests__/ingredient-list-projection.test.ts
+++ b/frontend/database/__tests__/ingredient-list-projection.test.ts
@@ -327,5 +327,32 @@ describe("IngredientListProjection", () => {
 
       warnSpy.mockRestore()
     })
+
+    // A DB write failure is infrastructure, not unreadable content - unlike
+    // a bad payload (skipped above), it must propagate out of rebuildForList
+    // so EventApplier.apply's transaction rolls back and the cursor doesn't
+    // advance past an event that never actually applied.
+    it("propagates a genuine db write failure instead of swallowing it like a bad payload", async () => {
+      const dbError = new Error("SQLITE_BUSY: database is locked")
+      const originalRunAsync = db.runAsync.bind(db)
+      let callCount = 0
+      jest
+        .spyOn(db, "runAsync")
+        .mockImplementation((...args: Parameters<typeof db.runAsync>) => {
+          callCount++
+          // 1st call is rebuildForList's own DELETE; 2nd is handleCreated's
+          // INSERT - fail that one specifically.
+          if (callCount === 2) {
+            return Promise.reject(dbError)
+          }
+          return originalRunAsync(...args)
+        })
+
+      await expect(
+        projection.rebuildForList(db, "list-1", [makeEvent()])
+      ).rejects.toThrow(dbError)
+
+      jest.restoreAllMocks()
+    })
   })
 })

--- a/frontend/database/__tests__/ingredient-list-projection.test.ts
+++ b/frontend/database/__tests__/ingredient-list-projection.test.ts
@@ -55,6 +55,36 @@ describe("IngredientListProjection", () => {
       expect(row).not.toBeNull()
     })
 
+    it("skips (doesn't throw) when the payload is not valid JSON", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(db, makeEvent({ payload: "{not json" }))
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(
+        `SELECT id FROM ingredient_lists WHERE id = 'list-1'`
+      )
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it("skips (doesn't throw) when a required field is missing", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(db, makeEvent({ payload: "{}" }))
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(
+        `SELECT id FROM ingredient_lists WHERE id = 'list-1'`
+      )
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
     it("upserts rather than throwing on a duplicate/echoed created event", async () => {
       await projection.handleCreated(db, makeEvent())
 
@@ -229,6 +259,72 @@ describe("IngredientListProjection", () => {
       await projection.rebuildForList(db, "list-1", [])
 
       expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    // Regression test for the poison-pill bug: a corrupt event mid-history
+    // used to throw out of rebuildForList, out of EventApplier's
+    // transaction, and leave the pull cursor stuck forever on this list.
+    // With totality, the bad event is skipped and every valid event either
+    // side of it still applies.
+    it("skips a corrupt event mid-history instead of aborting the whole rebuild", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.rebuildForList(db, "list-1", [
+          makeEvent({
+            event_id: "e1",
+            event_type: EventTypes.TODO_LIST_CREATED,
+            seq: 1,
+          }),
+          makeEvent({
+            event_id: "e2",
+            event_type: EventTypes.TODO_LIST_UPDATED,
+            payload: "{not valid json",
+            seq: 2,
+          }),
+          makeEvent({
+            event_id: "e3",
+            event_type: EventTypes.TODO_LIST_UPDATED,
+            payload: JSON.stringify({ name: "Lidl" }),
+            seq: 3,
+          }),
+        ])
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync<{ name: string }>(
+        `SELECT name FROM ingredient_lists WHERE id = 'list-1'`
+      )
+      // e1 (create) and e3 (rename to Lidl) both applied; only the corrupt
+      // e2 in between was skipped.
+      expect(row?.name).toBe("Lidl")
+      expect(warnSpy).toHaveBeenCalled()
+
+      warnSpy.mockRestore()
+    })
+
+    // Task 3: skipped events must be diagnosable through the same path as
+    // the existing drift case, not just a per-event log line - see
+    // SyncEngine.repairList.
+    it("warns with a repairList pointer summarizing how many events were skipped", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await projection.rebuildForList(db, "list-1", [
+        makeEvent({ event_id: "e1", seq: 1 }),
+        makeEvent({
+          event_id: "e2",
+          event_type: EventTypes.TODO_LIST_UPDATED,
+          payload: "{not valid json",
+          seq: 2,
+        }),
+      ])
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /skipped 1 unreadable event.*SyncEngine\.repairList/
+        )
+      )
+
       warnSpy.mockRestore()
     })
   })

--- a/frontend/database/__tests__/ingredient-projection.test.ts
+++ b/frontend/database/__tests__/ingredient-projection.test.ts
@@ -548,5 +548,32 @@ describe("IngredientProjection", () => {
 
       warnSpy.mockRestore()
     })
+
+    // A DB write failure is infrastructure, not unreadable content - unlike
+    // a bad payload (skipped above), it must propagate out of rebuildForList
+    // so EventApplier.apply's transaction rolls back and the cursor doesn't
+    // advance past an event that never actually applied.
+    it("propagates a genuine db write failure instead of swallowing it like a bad payload", async () => {
+      const dbError = new Error("SQLITE_BUSY: database is locked")
+      const originalRunAsync = db.runAsync.bind(db)
+      let callCount = 0
+      jest
+        .spyOn(db, "runAsync")
+        .mockImplementation((...args: Parameters<typeof db.runAsync>) => {
+          callCount++
+          // 1st call is rebuildForList's own DELETE; 2nd is handleCreated's
+          // INSERT - fail that one specifically.
+          if (callCount === 2) {
+            return Promise.reject(dbError)
+          }
+          return originalRunAsync(...args)
+        })
+
+      await expect(
+        projection.rebuildForList(db, "list-1", [makeEvent()])
+      ).rejects.toThrow(dbError)
+
+      jest.restoreAllMocks()
+    })
   })
 })

--- a/frontend/database/__tests__/ingredient-projection.test.ts
+++ b/frontend/database/__tests__/ingredient-projection.test.ts
@@ -85,6 +85,55 @@ describe("IngredientProjection", () => {
       })
     })
 
+    it("skips (doesn't throw) when the payload is not valid JSON", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(db, makeEvent({ payload: "{not json" }))
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(`SELECT id FROM ingredients`)
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it("skips (doesn't throw) when a required field is missing", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(db, makeEvent({ payload: "{}" }))
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(`SELECT id FROM ingredients`)
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    // The server authorizes writes on the envelope's list_id, not anything
+    // inside payload - a payload-carried listId must never be trusted, or a
+    // member of list Y could push an event authorized for Y that lands in
+    // list X locally.
+    it("uses the envelope's list_id, ignoring a divergent payload.listId", async () => {
+      await projection.handleCreated(
+        db,
+        makeEvent({
+          list_id: "list-Y",
+          payload: JSON.stringify({
+            name: "Milk",
+            listId: "list-X",
+            completed: false,
+          }),
+        })
+      )
+
+      const row = await db.getFirstAsync<{ list_id: string }>(
+        `SELECT list_id FROM ingredients WHERE id = 'ing-1'`
+      )
+      expect(row?.list_id).toBe("list-Y")
+    })
+
     it("is idempotent: applying the same created event twice updates in place instead of throwing", async () => {
       await projection.handleCreated(db, makeEvent())
 
@@ -427,6 +476,77 @@ describe("IngredientProjection", () => {
         `SELECT id FROM ingredients WHERE id = 'ing-1'`
       )
       expect(row).not.toBeNull()
+    })
+
+    // Regression test for the poison-pill bug: a corrupt event mid-history
+    // used to throw out of rebuildForList, out of EventApplier's
+    // transaction, and leave the pull cursor stuck forever on this list.
+    // With totality, the bad event is skipped and every valid event either
+    // side of it still applies.
+    it("skips a corrupt event mid-history instead of aborting the whole rebuild", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.rebuildForList(db, "list-1", [
+          makeEvent({
+            event_id: "e1",
+            event_type: EventTypes.INGREDIENT_CREATED,
+            aggregate_id: "a",
+            seq: 1,
+            payload: JSON.stringify({ name: "Apples", completed: false }),
+          }),
+          makeEvent({
+            event_id: "e2",
+            event_type: EventTypes.INGREDIENT_CREATED,
+            aggregate_id: "b",
+            seq: 2,
+            payload: "{not valid json",
+          }),
+          makeEvent({
+            event_id: "e3",
+            event_type: EventTypes.INGREDIENT_CREATED,
+            aggregate_id: "c",
+            seq: 3,
+            payload: JSON.stringify({ name: "Butter", completed: false }),
+          }),
+        ])
+      ).resolves.toBeUndefined()
+
+      const rows = await db.getAllAsync<{ id: string }>(
+        `SELECT id FROM ingredients ORDER BY id`
+      )
+      // a and c (valid) both applied; only the corrupt b in between was
+      // skipped.
+      expect(rows.map((r) => r.id)).toEqual(["a", "c"])
+      expect(warnSpy).toHaveBeenCalled()
+
+      warnSpy.mockRestore()
+    })
+
+    // Task 3: skipped events must be diagnosable through the same path as
+    // the existing drift case, not just a per-event log line - see
+    // SyncEngine.repairList.
+    it("warns with a repairList pointer summarizing how many events were skipped", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await projection.rebuildForList(db, "list-1", [
+        makeEvent({ event_id: "e1", seq: 1 }),
+        makeEvent({
+          event_id: "e2",
+          event_type: EventTypes.INGREDIENT_PRIORITY_SET,
+          aggregate_id: "ing-1",
+          payload: "{}",
+          seq: 2,
+        }),
+      ])
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /skipped 1 unreadable event.*SyncEngine\.repairList/
+        )
+      )
+
+      warnSpy.mockRestore()
     })
   })
 })

--- a/frontend/database/ingredient-list-projection.ts
+++ b/frontend/database/ingredient-list-projection.ts
@@ -8,8 +8,56 @@ import { createLogger } from "@/api/common/logger"
 
 const logger = createLogger("IngredientListProjection")
 
+type NamePayload = { name: string }
+
+function isNamePayload(value: unknown): value is NamePayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).name === "string"
+  )
+}
+
 export class IngredientListProjection {
   constructor(private readonly db: SQLiteDatabase) {}
+
+  // R4 (see frontend/docs/sync-server-registry-roadmap.md): a projection
+  // must never throw on a bad event - an unparseable/malformed payload from
+  // another device or client version is skipped and logged, not fatal.
+  // onSkip is optional and purely additive - it lets rebuildForList tally
+  // how many events it skipped without handle* methods having to change
+  // their (tested) void-resolving, never-throwing return contract.
+  private parsePayload<T>(
+    event: DomainEventRow,
+    isValid: (value: unknown) => value is T,
+    onSkip?: () => void
+  ): T | null {
+    let value: unknown
+    try {
+      value = JSON.parse(event.payload)
+    } catch {
+      this.logSkipped(event, "payload is not valid JSON", onSkip)
+      return null
+    }
+    if (!isValid(value)) {
+      this.logSkipped(event, "payload is missing a required field", onSkip)
+      return null
+    }
+    return value
+  }
+
+  private logSkipped(
+    event: DomainEventRow,
+    reason: string,
+    onSkip?: () => void
+  ): void {
+    logger.warn("Skipping event while rebuilding list projection", {
+      event_id: event.event_id,
+      event_type: event.event_type,
+      reason,
+    })
+    onSkip?.()
+  }
 
   /**
    * Upsert rather than a plain INSERT: rebuildForList/rebuild always DELETE
@@ -21,14 +69,16 @@ export class IngredientListProjection {
    */
   async handleCreated(
     db: SQLiteDatabase,
-    event: DomainEventRow
+    event: DomainEventRow,
+    onSkip?: () => void
   ): Promise<void> {
-    const { name } = JSON.parse(event.payload)
+    const payload = this.parsePayload(event, isNamePayload, onSkip)
+    if (!payload) return
     await db.runAsync(
       `INSERT INTO ingredient_lists (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)
        ON CONFLICT(id) DO UPDATE SET name = excluded.name, updated_at = excluded.updated_at`,
       event.aggregate_id,
-      name,
+      payload.name,
       event.occurred_at,
       event.occurred_at
     )
@@ -36,12 +86,14 @@ export class IngredientListProjection {
 
   async handleUpdated(
     db: SQLiteDatabase,
-    event: DomainEventRow
+    event: DomainEventRow,
+    onSkip?: () => void
   ): Promise<void> {
-    const { name } = JSON.parse(event.payload)
+    const payload = this.parsePayload(event, isNamePayload, onSkip)
+    if (!payload) return
     await db.runAsync(
       `UPDATE ingredient_lists SET name = ?, updated_at = ? WHERE id = ?`,
-      name,
+      payload.name,
       event.occurred_at,
       event.aggregate_id
     )
@@ -91,18 +143,22 @@ export class IngredientListProjection {
       )
     }
 
+    let skippedCount = 0
     for (const event of ordered) {
-      switch (event.event_type) {
-        case EventTypes.TODO_LIST_CREATED:
-          await this.handleCreated(db, event)
-          break
-        case EventTypes.TODO_LIST_UPDATED:
-          await this.handleUpdated(db, event)
-          break
-        case EventTypes.TODO_LIST_DELETED:
-          await this.handleDeleted(db, event)
-          break
+      if (await this.applyEvent(db, event)) {
+        skippedCount++
       }
+    }
+
+    // Same diagnosability pattern as the no-todo_list.created warning above:
+    // a rebuild that skipped events can't fix itself, but naming the repair
+    // path here keeps this discoverable through SyncEngine.repairList - the
+    // same place drift recovery already lives - instead of only a per-event
+    // log line.
+    if (skippedCount > 0) {
+      logger.warn(
+        `List ${listId} skipped ${skippedCount} unreadable event(s) during rebuild - see SyncEngine.repairList to re-derive it from the server`
+      )
     }
   }
 
@@ -111,18 +167,44 @@ export class IngredientListProjection {
       await this.db.runAsync(`DELETE FROM ingredient_lists`)
       const ordered = [...events].sort(byServerSeqThenLocal)
       for (const event of ordered) {
-        switch (event.event_type) {
-          case EventTypes.TODO_LIST_CREATED:
-            await this.handleCreated(this.db, event)
-            break
-          case EventTypes.TODO_LIST_UPDATED:
-            await this.handleUpdated(this.db, event)
-            break
-          case EventTypes.TODO_LIST_DELETED:
-            await this.handleDeleted(this.db, event)
-            break
-        }
+        await this.applyEvent(this.db, event)
       }
     })
+  }
+
+  // Belt-and-suspenders on top of parsePayload's field validation: any
+  // handler that still throws (e.g. an unforeseen bad shape) must not take
+  // the rest of the rebuild down with it - R4 applies to the whole dispatch,
+  // not just JSON parsing. Returns whether the event was skipped, so callers
+  // can tally it (see rebuildForList's aggregate warning above).
+  private async applyEvent(
+    db: SQLiteDatabase,
+    event: DomainEventRow
+  ): Promise<boolean> {
+    let skipped = false
+    const onSkip = () => {
+      skipped = true
+    }
+    try {
+      switch (event.event_type) {
+        case EventTypes.TODO_LIST_CREATED:
+          await this.handleCreated(db, event, onSkip)
+          break
+        case EventTypes.TODO_LIST_UPDATED:
+          await this.handleUpdated(db, event, onSkip)
+          break
+        case EventTypes.TODO_LIST_DELETED:
+          await this.handleDeleted(db, event)
+          break
+      }
+    } catch (error) {
+      logger.warn("Skipping event that failed to apply to list projection", {
+        event_id: event.event_id,
+        event_type: event.event_type,
+        reason: error,
+      })
+      skipped = true
+    }
+    return skipped
   }
 }

--- a/frontend/database/ingredient-list-projection.ts
+++ b/frontend/database/ingredient-list-projection.ts
@@ -172,11 +172,11 @@ export class IngredientListProjection {
     })
   }
 
-  // Belt-and-suspenders on top of parsePayload's field validation: any
-  // handler that still throws (e.g. an unforeseen bad shape) must not take
-  // the rest of the rebuild down with it - R4 applies to the whole dispatch,
-  // not just JSON parsing. Returns whether the event was skipped, so callers
-  // can tally it (see rebuildForList's aggregate warning above).
+  // R4 only covers content we can't read - parsePayload already skips that.
+  // db.runAsync is the one remaining throw source here, and that's a write
+  // failure (locked/full/aborted/constraint), not a bad payload: it must
+  // propagate so EventApplier.apply's transaction rolls back and the cursor
+  // doesn't advance past events that never actually applied.
   private async applyEvent(
     db: SQLiteDatabase,
     event: DomainEventRow
@@ -185,25 +185,16 @@ export class IngredientListProjection {
     const onSkip = () => {
       skipped = true
     }
-    try {
-      switch (event.event_type) {
-        case EventTypes.TODO_LIST_CREATED:
-          await this.handleCreated(db, event, onSkip)
-          break
-        case EventTypes.TODO_LIST_UPDATED:
-          await this.handleUpdated(db, event, onSkip)
-          break
-        case EventTypes.TODO_LIST_DELETED:
-          await this.handleDeleted(db, event)
-          break
-      }
-    } catch (error) {
-      logger.warn("Skipping event that failed to apply to list projection", {
-        event_id: event.event_id,
-        event_type: event.event_type,
-        reason: error,
-      })
-      skipped = true
+    switch (event.event_type) {
+      case EventTypes.TODO_LIST_CREATED:
+        await this.handleCreated(db, event, onSkip)
+        break
+      case EventTypes.TODO_LIST_UPDATED:
+        await this.handleUpdated(db, event, onSkip)
+        break
+      case EventTypes.TODO_LIST_DELETED:
+        await this.handleDeleted(db, event)
+        break
     }
     return skipped
   }

--- a/frontend/database/ingredient-projection.ts
+++ b/frontend/database/ingredient-projection.ts
@@ -226,11 +226,11 @@ export class IngredientProjection {
     })
   }
 
-  // Belt-and-suspenders on top of parsePayload's field validation: any
-  // handler that still throws (e.g. an unforeseen bad shape) must not take
-  // the rest of the rebuild down with it - R4 applies to the whole dispatch,
-  // not just JSON parsing. Returns whether the event was skipped, so callers
-  // can tally it (see rebuildForList's aggregate warning above).
+  // R4 only covers content we can't read - parsePayload already skips that.
+  // db.runAsync is the one remaining throw source here, and that's a write
+  // failure (locked/full/aborted/constraint), not a bad payload: it must
+  // propagate so EventApplier.apply's transaction rolls back and the cursor
+  // doesn't advance past events that never actually applied.
   private async applyEvent(
     db: SQLiteDatabase,
     event: DomainEventRow
@@ -239,34 +239,22 @@ export class IngredientProjection {
     const onSkip = () => {
       skipped = true
     }
-    try {
-      switch (event.event_type) {
-        case EventTypes.INGREDIENT_CREATED:
-          await this.handleCreated(db, event, onSkip)
-          break
-        case EventTypes.INGREDIENT_UPDATED:
-          await this.handleUpdated(db, event, onSkip)
-          break
-        case EventTypes.INGREDIENT_PRIORITY_SET:
-          await this.handlePrioritySet(db, event, onSkip)
-          break
-        case EventTypes.INGREDIENT_PRIORITY_CLEARED:
-          await this.handlePriorityCleared(db, event)
-          break
-        case EventTypes.INGREDIENT_DELETED:
-          await this.handleDeleted(db, event)
-          break
-      }
-    } catch (error) {
-      logger.warn(
-        "Skipping event that failed to apply to ingredient projection",
-        {
-          event_id: event.event_id,
-          event_type: event.event_type,
-          reason: error,
-        }
-      )
-      skipped = true
+    switch (event.event_type) {
+      case EventTypes.INGREDIENT_CREATED:
+        await this.handleCreated(db, event, onSkip)
+        break
+      case EventTypes.INGREDIENT_UPDATED:
+        await this.handleUpdated(db, event, onSkip)
+        break
+      case EventTypes.INGREDIENT_PRIORITY_SET:
+        await this.handlePrioritySet(db, event, onSkip)
+        break
+      case EventTypes.INGREDIENT_PRIORITY_CLEARED:
+        await this.handlePriorityCleared(db, event)
+        break
+      case EventTypes.INGREDIENT_DELETED:
+        await this.handleDeleted(db, event)
+        break
     }
     return skipped
   }

--- a/frontend/database/ingredient-projection.ts
+++ b/frontend/database/ingredient-projection.ts
@@ -4,15 +4,85 @@ import {
   EventTypes,
   byServerSeqThenLocal,
 } from "@/types/DomainEvent"
+import { createLogger } from "@/api/common/logger"
+
+const logger = createLogger("IngredientProjection")
+
+type CreatedPayload = {
+  name: string
+  completed?: unknown
+  completedAt?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isCreatedPayload(value: unknown): value is CreatedPayload {
+  return isRecord(value) && typeof value.name === "string"
+}
+
+function isPrioritySetPayload(value: unknown): value is { priority: number } {
+  return isRecord(value) && typeof value.priority === "number"
+}
 
 export class IngredientProjection {
   constructor(private readonly db: SQLiteDatabase) {}
 
+  // R4 (see frontend/docs/sync-server-registry-roadmap.md): a projection
+  // must never throw on a bad event - an unparseable/malformed payload from
+  // another device or client version is skipped and logged, not fatal.
+  // onSkip is optional and purely additive - it lets rebuildForList tally
+  // how many events it skipped without handle* methods having to change
+  // their (tested) void-resolving, never-throwing return contract.
+  private parsePayload<T>(
+    event: DomainEventRow,
+    isValid: (value: unknown) => value is T,
+    onSkip?: () => void
+  ): T | null {
+    let value: unknown
+    try {
+      value = JSON.parse(event.payload)
+    } catch {
+      this.logSkipped(event, "payload is not valid JSON", onSkip)
+      return null
+    }
+    if (!isValid(value)) {
+      this.logSkipped(event, "payload is missing a required field", onSkip)
+      return null
+    }
+    return value
+  }
+
+  private logSkipped(
+    event: DomainEventRow,
+    reason: string,
+    onSkip?: () => void
+  ): void {
+    logger.warn("Skipping event while rebuilding ingredient projection", {
+      event_id: event.event_id,
+      event_type: event.event_type,
+      reason,
+    })
+    onSkip?.()
+  }
+
   async handleCreated(
     db: SQLiteDatabase,
-    event: DomainEventRow
+    event: DomainEventRow,
+    onSkip?: () => void
   ): Promise<void> {
-    const { name, listId, completed, completedAt } = JSON.parse(event.payload)
+    const payload = this.parsePayload(event, isCreatedPayload, onSkip)
+    if (!payload) return
+    // list_id comes from the envelope, not the payload: authorization is
+    // enforced server-side on the envelope's list_id, so trusting a
+    // payload-carried listId would let a member of list Y push an event
+    // that's authorized for Y but lands in list X locally (see
+    // sync-server-registry-roadmap.md).
+    if (event.list_id === null) {
+      this.logSkipped(event, "event has no list_id on its envelope", onSkip)
+      return
+    }
     // ON CONFLICT rather than a bare INSERT: a scoped projection rebuild
     // (rebuildForList) replays a list's *entire* merged local+pulled
     // history from scratch every time new remote events land, and two
@@ -30,21 +100,27 @@ export class IngredientProjection {
          updated_at = excluded.updated_at,
          completed_at = excluded.completed_at`,
       event.aggregate_id,
-      name,
-      completed ? 1 : 0,
-      listId,
+      payload.name,
+      payload.completed ? 1 : 0,
+      event.list_id,
       event.occurred_at,
       event.occurred_at,
-      completedAt ?? null
+      (payload.completedAt as number | null | undefined) ?? null
     )
   }
 
   async handleUpdated(
     db: SQLiteDatabase,
-    event: DomainEventRow
+    event: DomainEventRow,
+    onSkip?: () => void
   ): Promise<void> {
-    const payload = JSON.parse(event.payload)
+    const payload = this.parsePayload(event, isRecord, onSkip)
+    if (!payload) return
     if ("name" in payload) {
+      if (typeof payload.name !== "string") {
+        this.logSkipped(event, "payload.name is not a string", onSkip)
+        return
+      }
       await db.runAsync(
         `UPDATE ingredients SET name = ?, updated_at = ? WHERE id = ?`,
         payload.name,
@@ -56,7 +132,7 @@ export class IngredientProjection {
         `UPDATE ingredients SET completed = ?, updated_at = ?, completed_at = ? WHERE id = ?`,
         payload.completed ? 1 : 0,
         event.occurred_at,
-        payload.completedAt ?? null,
+        (payload.completedAt as number | null | undefined) ?? null,
         event.aggregate_id
       )
     }
@@ -64,12 +140,14 @@ export class IngredientProjection {
 
   async handlePrioritySet(
     db: SQLiteDatabase,
-    event: DomainEventRow
+    event: DomainEventRow,
+    onSkip?: () => void
   ): Promise<void> {
-    const { priority } = JSON.parse(event.payload)
+    const payload = this.parsePayload(event, isPrioritySetPayload, onSkip)
+    if (!payload) return
     await db.runAsync(
       `UPDATE ingredients SET priority = ?, updated_at = ? WHERE id = ?`,
-      priority,
+      payload.priority,
       event.occurred_at,
       event.aggregate_id
     )
@@ -119,24 +197,22 @@ export class IngredientProjection {
     // place that actually replays events is cheaper than auditing every
     // future call site.
     const ordered = [...events].sort(byServerSeqThenLocal)
+    let skippedCount = 0
     for (const event of ordered) {
-      switch (event.event_type) {
-        case EventTypes.INGREDIENT_CREATED:
-          await this.handleCreated(db, event)
-          break
-        case EventTypes.INGREDIENT_UPDATED:
-          await this.handleUpdated(db, event)
-          break
-        case EventTypes.INGREDIENT_PRIORITY_SET:
-          await this.handlePrioritySet(db, event)
-          break
-        case EventTypes.INGREDIENT_PRIORITY_CLEARED:
-          await this.handlePriorityCleared(db, event)
-          break
-        case EventTypes.INGREDIENT_DELETED:
-          await this.handleDeleted(db, event)
-          break
+      if (await this.applyEvent(db, event)) {
+        skippedCount++
       }
+    }
+
+    // Same diagnosability pattern as
+    // IngredientListProjection.rebuildForList's aggregate warning: naming
+    // the repair path here keeps this discoverable through
+    // SyncEngine.repairList - the same place drift recovery already lives -
+    // instead of only a per-event log line.
+    if (skippedCount > 0) {
+      logger.warn(
+        `List ${listId} skipped ${skippedCount} unreadable event(s) during rebuild - see SyncEngine.repairList to re-derive it from the server`
+      )
     }
   }
 
@@ -145,24 +221,53 @@ export class IngredientProjection {
       await this.db.runAsync(`DELETE FROM ingredients`)
       const ordered = [...events].sort(byServerSeqThenLocal)
       for (const event of ordered) {
-        switch (event.event_type) {
-          case EventTypes.INGREDIENT_CREATED:
-            await this.handleCreated(this.db, event)
-            break
-          case EventTypes.INGREDIENT_UPDATED:
-            await this.handleUpdated(this.db, event)
-            break
-          case EventTypes.INGREDIENT_PRIORITY_SET:
-            await this.handlePrioritySet(this.db, event)
-            break
-          case EventTypes.INGREDIENT_PRIORITY_CLEARED:
-            await this.handlePriorityCleared(this.db, event)
-            break
-          case EventTypes.INGREDIENT_DELETED:
-            await this.handleDeleted(this.db, event)
-            break
-        }
+        await this.applyEvent(this.db, event)
       }
     })
+  }
+
+  // Belt-and-suspenders on top of parsePayload's field validation: any
+  // handler that still throws (e.g. an unforeseen bad shape) must not take
+  // the rest of the rebuild down with it - R4 applies to the whole dispatch,
+  // not just JSON parsing. Returns whether the event was skipped, so callers
+  // can tally it (see rebuildForList's aggregate warning above).
+  private async applyEvent(
+    db: SQLiteDatabase,
+    event: DomainEventRow
+  ): Promise<boolean> {
+    let skipped = false
+    const onSkip = () => {
+      skipped = true
+    }
+    try {
+      switch (event.event_type) {
+        case EventTypes.INGREDIENT_CREATED:
+          await this.handleCreated(db, event, onSkip)
+          break
+        case EventTypes.INGREDIENT_UPDATED:
+          await this.handleUpdated(db, event, onSkip)
+          break
+        case EventTypes.INGREDIENT_PRIORITY_SET:
+          await this.handlePrioritySet(db, event, onSkip)
+          break
+        case EventTypes.INGREDIENT_PRIORITY_CLEARED:
+          await this.handlePriorityCleared(db, event)
+          break
+        case EventTypes.INGREDIENT_DELETED:
+          await this.handleDeleted(db, event)
+          break
+      }
+    } catch (error) {
+      logger.warn(
+        "Skipping event that failed to apply to ingredient projection",
+        {
+          event_id: event.event_id,
+          event_type: event.event_type,
+          reason: error,
+        }
+      )
+      skipped = true
+    }
+    return skipped
   }
 }


### PR DESCRIPTION
Roadmap-Schritt 1 aus `frontend/docs/sync-server-registry-roadmap.md`.

## Das Problem

Beide Projektionen parsen `event.payload` ungeschützt. Ein Event mit kaputtem oder unvollständigem Payload — von einem anderen Gerät, einer neueren App-Version oder einem bösartigen Client — löst folgende Kette aus:

`JSON.parse` throw → raus aus `rebuildForList` → raus aus der Transaktion in `EventApplier.apply` → dort gefangen, `Result.fail` → `SyncEngine.pullList` loggt und returnt, **ohne den Pull-Cursor zu setzen**.

Der nächste Pull holt dieselbe Seite und scheitert identisch. **Die Liste synchronisiert auf diesem Gerät nie wieder** — eine Logzeile, kein Nutzer-Signal, keine Selbstheilung.

Serverseitige Validierung kann das nicht heilen: das Log ist append-only, und der Server soll per Design nicht in Payloads hineinsehen. Deshalb muss die Abwehr hier liegen.

## Änderungen

**Totalität.** Payload-Parsen läuft über einen `parsePayload`-Helfer mit Type-Guards. Ein Event, dessen Payload nicht parst oder dessen benötigte Felder fehlen, wird übersprungen, geloggt und gezählt — nie geworfen. Die Rebuild-Schleife läuft weiter, alle gültigen Events werden angewendet.

**Abgrenzung zu Infrastrukturfehlern.** Ein fehlgeschlagenes `db.runAsync` propagiert weiterhin und reißt die Transaktion — der Cursor bleibt stehen und der nächste Pull versucht es erneut. Das ist der Unterschied, auf den es ankommt: unlesbarer Inhalt ist dauerhaft und wird übersprungen, ein DB-Fehler ist transient und muss durchschlagen. Ein Catch über beidem würde die Projektion still vom Log wegdriften lassen.

**Envelope statt Payload.** `IngredientProjection.handleCreated` nimmt `event.list_id` statt `payload.listId`. Autorisiert wird serverseitig über das Envelope-Feld; das Payload-Feld war unautorisiert. Ein Mitglied von Liste Y konnte ein Event mit Envelope-`list_id=Y` und Payload-`listId=X` pushen, und bei allen Y-Mitgliedern erschien der Eintrag lokal in Liste X. Statt beide Felder zu vergleichen, wird das Payload-Feld nicht mehr gelesen — die Divergenz ist damit nicht darstellbar.

**Nebenbei gefixt:** `handleUpdated` machte `"name" in payload` ungeschützt, was bei `null`- oder Primitiv-Payload wirft.

## Tests

- Korruptes Event **mitten** in der Historie: Rebuild läuft durch, umliegende Events angewendet. Auf Integrationsebene zusätzlich: `apply()` meldet Erfolg, Cursor rückt vor, Folge-Pull läuft — der eigentliche Regressionstest.
- Payload parst, aber Pflichtfeld fehlt → übersprungen.
- Echter DB-Schreibfehler → propagiert, im Kontrast zum übersprungenen Payload.
- Envelope-`list_id=Y` / Payload-`listId=X` → Eintrag landet in Y.

484 Tests grün, `pnpm lint` sauber.