### PR TITLE
feat(backend): validate event structure synchronously at the push endpoint

### DIFF
--- a/backend/internal/interface/api/rest/event-controller.go
+++ b/backend/internal/interface/api/rest/event-controller.go
@@ -1,9 +1,12 @@
 package rest
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -12,6 +15,25 @@ import (
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/application/services"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/middleware"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/interface/api/rest/dto/request"
+)
+
+const (
+	// maxEventPayloadBytes bounds a single event's payload. A shopping-list
+	// event payload (a list/item name, maybe a short note) is realistically
+	// well under 1 KB; this leaves generous headroom for legitimate use
+	// while still bounding a malformed or hostile payload.
+	maxEventPayloadBytes = 8 * 1024
+	// maxBatchPayloadBytes bounds a batch's combined payload size. The
+	// client flushes at most 50 events per push (see
+	// OutboxRepository.getPending's default page size), so this comfortably
+	// covers even a large offline backlog of normal-sized events without
+	// allowing an unbounded batch.
+	maxBatchPayloadBytes = 64 * 1024
+
+	// todoListEventTypePrefix marks events whose aggregate *is* the list
+	// (see events.EventTypeCreateToDoList and friends) - only for these is
+	// an aggregate_id addressing a different list a structural error.
+	todoListEventTypePrefix = "todo_list."
 )
 
 type EventController struct {
@@ -47,6 +69,11 @@ func NewEventController(
 // yet no longer poisons the events behind it (see EventDispatcher's
 // forward-compatible unknown-type handling and EventIngestor's per-event
 // processing).
+//
+// validateEventStructure runs before authorization: it's a cheap, local
+// check of the envelope only (never the payload's fields, see its own
+// comment) - like git fsck, not a content review - so it rejects a
+// malformed batch before spending a DB round-trip on it.
 func (ec *EventController) SyncEvents(c echo.Context) error {
 	userID, ok := middleware.UserIDFromContext(c)
 	if !ok {
@@ -64,6 +91,11 @@ func (ec *EventController) SyncEvents(c echo.Context) error {
 
 	listIDs, err := distinctListIDs(events)
 	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		})
+	}
+	if err := validateEventStructure(events); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{
 			"error": err.Error(),
 		})
@@ -111,4 +143,39 @@ func distinctListIDs(events []request.SyncEventRequest) ([]uuid.UUID, error) {
 		ids = append(ids, *event.ListID)
 	}
 	return ids, nil
+}
+
+// validateEventStructure enforces the envelope-only rules the server may
+// check without parsing payload content: event_id/aggregate_id must be
+// real UUIDs, a todo_list.* event's aggregate_id must equal its own
+// list_id (list_id itself is already required by distinctListIDs, called
+// before this), payload must be syntactically valid JSON, and both
+// per-event and per-batch payload size stay bounded. It deliberately never
+// looks at a field inside payload - an unknown event_type or a semantically
+// invalid payload (e.g. an empty name) is not this function's concern, see
+// SyncEvents's doc comment.
+func validateEventStructure(events []request.SyncEventRequest) error {
+	var batchBytes int
+	for _, event := range events {
+		if event.EventID == uuid.Nil {
+			return fmt.Errorf("event_id is required")
+		}
+		if event.AggregateID == uuid.Nil {
+			return fmt.Errorf("aggregate_id is required")
+		}
+		if strings.HasPrefix(event.EventType, todoListEventTypePrefix) && event.AggregateID != *event.ListID {
+			return fmt.Errorf("event %s: aggregate_id must equal list_id for %s events", event.EventID, event.EventType)
+		}
+		if len(event.Payload) > maxEventPayloadBytes {
+			return fmt.Errorf("event %s: payload exceeds %d bytes", event.EventID, maxEventPayloadBytes)
+		}
+		if !json.Valid(event.Payload) {
+			return fmt.Errorf("event %s: payload is not valid JSON", event.EventID)
+		}
+		batchBytes += len(event.Payload)
+		if batchBytes > maxBatchPayloadBytes {
+			return fmt.Errorf("batch payload exceeds %d bytes", maxBatchPayloadBytes)
+		}
+	}
+	return nil
 }

--- a/backend/internal/interface/api/rest/event-controller_test.go
+++ b/backend/internal/interface/api/rest/event-controller_test.go
@@ -309,3 +309,201 @@ func TestEventController_SyncEvents_DeniedListReturns403AndEnqueuesNothing(t *te
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.NotContains(t, repo.stored, eventID, "a rejected batch must not enqueue any of its events")
 }
+
+// syncEvent builds one event JSON object for a request body. payload must
+// itself be a valid JSON value (or the empty string to omit the field
+// entirely) - see TestEventController_SyncEvents_MissingPayloadReturns400's
+// comment for why "syntactically invalid JSON payload" can only be reached
+// that way once the request has to bind as valid JSON in the first place.
+func syncEvent(eventID, aggregateID, aggregateType, eventType string, listID *uuid.UUID, payload string) string {
+	listIDField := "null"
+	if listID != nil {
+		listIDField = `"` + listID.String() + `"`
+	}
+	payloadField := ""
+	if payload != "" {
+		payloadField = `, "payload": ` + payload
+	}
+	return `{
+		"event_id": "` + eventID + `",
+		"event_type": "` + eventType + `",
+		"aggregate_id": "` + aggregateID + `",
+		"aggregate_type": "` + aggregateType + `",
+		"list_id": ` + listIDField + `,
+		"occurred_at": 1700000000000,
+		"client_id": "client-1"` + payloadField + `
+	}`
+}
+
+// TestEventController_SyncEvents_MissingPayloadReturns400 is this
+// controller's json.Valid(payload) check. It cannot be triggered by a
+// syntactically-broken payload value (e.g. "{name": ) - the outer request
+// body would then fail to parse as JSON at all, well before
+// validateEventStructure ever sees it, and that's already covered by
+// TestEventController_SyncEvents_MalformedBodyReturns400. The only payload
+// that is well-formed enough for the request to bind but still fails
+// json.Valid is a payload field that's missing outright (an empty
+// json.RawMessage) - e.g. an older or buggy client that dropped the field.
+func TestEventController_SyncEvents_MissingPayloadReturns400(t *testing.T) {
+	e, repo, _ := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	eventID := uuid.New()
+	listID := uuid.New()
+	body := "[" + syncEvent(eventID.String(), listID.String(), "todo_list", "todo_list.created", &listID, "") + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, repo.stored, eventID, "a structurally invalid event must not reach the events table")
+}
+
+// TestEventController_SyncEvents_ToDoListEventWithMismatchedAggregateIDReturns400
+// is the addressing check: a todo_list.* event's aggregate_id must equal
+// its own list_id, since for these event types the list is the aggregate.
+func TestEventController_SyncEvents_ToDoListEventWithMismatchedAggregateIDReturns400(t *testing.T) {
+	e, repo, _ := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	eventID := uuid.New()
+	listID := uuid.New()
+	otherAggregateID := uuid.New()
+	body := "[" + syncEvent(eventID.String(), otherAggregateID.String(), "todo_list", "todo_list.created", &listID, `{"name": "Rewe"}`) + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, repo.stored, eventID)
+}
+
+// TestEventController_SyncEvents_OversizedEventPayloadReturns400 checks the
+// per-event size cap (maxEventPayloadBytes).
+func TestEventController_SyncEvents_OversizedEventPayloadReturns400(t *testing.T) {
+	e, repo, _ := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	eventID := uuid.New()
+	listID := uuid.New()
+	oversizedName := `"` + strings.Repeat("a", maxEventPayloadBytes+1) + `"`
+	body := "[" + syncEvent(eventID.String(), listID.String(), "todo_list", "todo_list.created", &listID, `{"name": `+oversizedName+`}`) + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, repo.stored, eventID)
+}
+
+// TestEventController_SyncEvents_OversizedBatchReturns400 checks the
+// per-batch size cap (maxBatchPayloadBytes): every individual event here
+// stays under maxEventPayloadBytes, only their sum exceeds
+// maxBatchPayloadBytes.
+func TestEventController_SyncEvents_OversizedBatchReturns400(t *testing.T) {
+	e, repo, _ := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	const perEventSize = maxEventPayloadBytes - 200
+	const numEvents = (maxBatchPayloadBytes / perEventSize) + 2
+
+	eventIDs := make([]uuid.UUID, numEvents)
+	parts := make([]string, numEvents)
+	name := `"` + strings.Repeat("a", perEventSize) + `"`
+	for i := range parts {
+		eventIDs[i] = uuid.New()
+		listID := uuid.New()
+		parts[i] = syncEvent(eventIDs[i].String(), listID.String(), "todo_list", "todo_list.created", &listID, `{"name": `+name+`}`)
+	}
+	body := "[" + strings.Join(parts, ",") + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, repo.stored, eventIDs[0], "a rejected batch must not enqueue any of its events")
+}
+
+// TestEventController_SyncEvents_OneStructurallyBrokenEventRejectsWholeBatch
+// mirrors TestEventController_SyncEvents_DeniedListReturns403AndEnqueuesNothing
+// for validateEventStructure: one bad event anywhere in the batch means
+// none of the batch's events - including otherwise-fine ones - get
+// enqueued, matching distinctListIDs/AuthorizeWrite's existing all-or-
+// nothing semantics.
+func TestEventController_SyncEvents_OneStructurallyBrokenEventRejectsWholeBatch(t *testing.T) {
+	e, repo, _ := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	goodEventID := uuid.New()
+	goodListID := uuid.New()
+	brokenEventID := uuid.New()
+	brokenListID := uuid.New()
+	body := "[" +
+		syncEvent(goodEventID.String(), goodListID.String(), "todo_list", "todo_list.created", &goodListID, `{"name": "Rewe"}`) +
+		"," +
+		syncEvent(brokenEventID.String(), brokenListID.String(), "todo_list", "todo_list.created", &brokenListID, "") +
+		"]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.NotContains(t, repo.stored, goodEventID)
+	assert.NotContains(t, repo.stored, brokenEventID)
+}
+
+// TestEventController_SyncEvents_UnknownEventTypeIsAcceptedAndRelayed is the
+// forward-compatibility counterpart to every rejection test above: a
+// structurally valid event of a type this server doesn't know about (e.g.
+// from a newer client) must still be accepted and enqueued, not rejected
+// with a 400 - the frontend treats 400 as non-retryable and disables sync
+// for the whole list on it (see sync-client.ts's nonRetryableError).
+func TestEventController_SyncEvents_UnknownEventTypeIsAcceptedAndRelayed(t *testing.T) {
+	e, _, ack := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	eventID := uuid.New()
+	aggregateID := uuid.New()
+	listID := uuid.New()
+	body := "[" + syncEvent(eventID.String(), aggregateID.String(), "widget", "widget.frobbed", &listID, `{"whatever": "the server has never heard of this"}`) + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	require.Eventually(t, func() bool { return ack.acked[eventID] }, time.Second, time.Millisecond)
+}
+
+// TestEventController_SyncEvents_EmptyNameToDoListCreatedIsAccepted
+// documents that the server is deliberately blind to payload content: it
+// validates structure (this event's aggregate_id equals its list_id,
+// payload is valid JSON, sizes are in bounds), never semantics. An empty
+// name is a client-side concern to harden separately.
+func TestEventController_SyncEvents_EmptyNameToDoListCreatedIsAccepted(t *testing.T) {
+	e, _, ack := newTestEventController(t, allowAllAccess(), withUserID("user-1"))
+
+	eventID := uuid.New()
+	listID := uuid.New()
+	body := "[" + syncEvent(eventID.String(), listID.String(), "todo_list", "todo_list.created", &listID, `{"name": ""}`) + "]"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/events", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	require.Eventually(t, func() bool { return ack.acked[eventID] }, time.Second, time.Millisecond)
+}


### PR DESCRIPTION
Roadmap-Schritt 2 aus `frontend/docs/sync-server-registry-roadmap.md`.

## Warum

Der Server soll ein append-only Log sein, das Struktur prüft und Inhalt niemals interpretiert — `git fsck` prüft, ob ein Objekt wohlgeformt ist, nie ob die Commit-Message leer ist. Heute passiert die einzige Ablehnung eines Events in einem Background-Worker ohne Request-Context, der nur „ewig retryen" oder „schlucken" kann. Alles, was „nein" sagen darf, gehört synchron in den Push-Handler, direkt neben `AuthorizeWrite`.

## Änderungen

`validateEventStructure` läuft in `SyncEvents` nach `distinctListIDs` und vor `AuthorizeWrite` (lokale Prüfung vor dem DB-Round-Trip). Geprüft wird pro Event:

- `event_id` und `aggregate_id` sind vorhanden und UUID-förmig
- `aggregate_id == list_id` für `todo_list.*` — bei diesen Events *ist* die Liste das Aggregat, das ist Adressierung, nicht Inhalt
- `payload` ist syntaktisch valides JSON (`json.Valid`, kein `Unmarshal` in einen Zieltyp)
- Größenobergrenzen: 8 KiB pro Event, 64 KiB pro Batch

Verstoß → 400, ganze Batch abgelehnt, nichts enqueued (dieselbe All-or-nothing-Semantik wie die bestehenden Prüfungen).

## Was bewusst NICHT geprüft wird

**Keine semantischen Feldprüfungen.** Ein `todo_list.created` mit leerem `name` wird angenommen. Der Server ist blind; die Abwehr gegen unbrauchbaren Inhalt liegt im Client (#251).

**Keine Ablehnung unbekannter Event-Typen.** Ein neuerer Client muss gegen einen älteren Server pushen können. Ein 400 wäre hier besonders teuer: der Client behandelt 400 als non-retryable und schaltet daraufhin Sync für die *ganze Liste* auf diesem Gerät ab (`sync-client.ts` → `giveUpOnGroup`). Ein neuer Event-Typ würde also nicht ein Event verlieren, sondern die Synchronisation der Liste.

Beides ist als Positivtest festgehalten, damit es nicht versehentlich „repariert" wird.

Nebeneffekt: `json.Valid` greift real nur, wenn das `payload`-Feld ganz fehlt — `Payload` ist `json.RawMessage`, syntaktisch kaputtes JSON scheitert schon am äußeren Decoder (bereits abgedeckt). Die Prüfung bleibt als billige, explizite Zusicherung drin.

## Nicht Teil dieses PRs

`ErrPermanent` bleibt vorerst. Die strukturelle Prüfung lässt einen leeren Namen absichtlich durch, das Event erreicht also weiterhin `CreateToDoList` und scheitert dort — ohne `ErrPermanent` wäre das der Regress aus #247 zurück (Sweep alle 30 s, Fehlerzeile pro Versuch, unbegrenzt). Der Mechanismus entfällt erst, wenn der Dispatch-Pfad selbst verschwindet.

## Tests

400: fehlender Payload, `aggregate_id != list_id`, Event über Limit, Batch über Limit, ein kaputtes Event kippt die ganze Batch.
202 + Ack: unbekannter Event-Typ mit validem Envelope, `todo_list.created` mit leerem `name`.

`go build`, `go vet`, `go test ./...` grün.