### PR TITLE
feat(backend): answer "does the server know this list" from a registry

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -58,10 +58,11 @@ func run(logger *slog.Logger) error {
 	eventRepo := postgres2.NewSqlcEventRepository(queries)
 	listInviteRepo := postgres2.NewSqlcListInviteRepository(queries)
 	listMemberRepo := postgres2.NewSqlcListMemberRepository(queries)
+	syncedListRepo := postgres2.NewSqlcSyncedListRepository(queries)
 
 	toDoListService := services.NewToDoListService(toDoListRepo)
 	listAccessService := services.NewListAccessService(listMemberRepo)
-	listSharingService := services.NewListSharingService(logger, listInviteRepo, listMemberRepo, toDoListRepo, listAccessService)
+	listSharingService := services.NewListSharingService(logger, listInviteRepo, listMemberRepo, syncedListRepo, listAccessService)
 
 	eventDispatcher := services.NewEventDispatcher(
 		logger,

--- a/backend/internal/application/command/redeem-list-invite-command.go
+++ b/backend/internal/application/command/redeem-list-invite-command.go
@@ -13,9 +13,8 @@ type RedeemListInviteCommand struct {
 }
 
 type RedeemListInviteCommandResult struct {
-	ListID   uuid.UUID
-	ListName string
-	Role     entities.ListMemberRole
+	ListID uuid.UUID
+	Role   entities.ListMemberRole
 	// AlreadyMember is true when the caller was already a member of the
 	// list before this redeem - a successful no-op, not an error.
 	AlreadyMember bool

--- a/backend/internal/application/services/list-sharing-service.go
+++ b/backend/internal/application/services/list-sharing-service.go
@@ -17,38 +17,41 @@ import (
 )
 
 type ListSharingService struct {
-	logger    *slog.Logger
-	invites   repositories.ListInviteRepository
-	members   repositories.ListMemberRepository
-	todoLists repositories.ToDoListRepository
-	access    interfaces.ListAccessService
+	logger  *slog.Logger
+	invites repositories.ListInviteRepository
+	members repositories.ListMemberRepository
+	lists   repositories.SyncedListRepository
+	access  interfaces.ListAccessService
 }
 
 func NewListSharingService(
 	logger *slog.Logger,
 	invites repositories.ListInviteRepository,
 	members repositories.ListMemberRepository,
-	todoLists repositories.ToDoListRepository,
+	lists repositories.SyncedListRepository,
 	access interfaces.ListAccessService,
 ) interfaces.ListSharingService {
 	return &ListSharingService{
-		logger:    logger,
-		invites:   invites,
-		members:   members,
-		todoLists: todoLists,
-		access:    access,
+		logger:  logger,
+		invites: invites,
+		members: members,
+		lists:   lists,
+		access:  access,
 	}
 }
 
-func (s *ListSharingService) requireList(ctx context.Context, listID uuid.UUID) (*entities.ToDoList, error) {
-	list, err := s.todoLists.FindById(ctx, listID)
+// requireList asks the registry, not a content projection: "synchronized"
+// means the server holds a log for this list, nothing more. It returns no
+// entity because there is none to return - the server has no list content.
+func (s *ListSharingService) requireList(ctx context.Context, listID uuid.UUID) error {
+	exists, err := s.lists.Exists(ctx, listID)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if list == nil {
-		return nil, interfaces.ErrListNotFound
+	if !exists {
+		return interfaces.ErrListNotFound
 	}
-	return list, nil
+	return nil
 }
 
 func (s *ListSharingService) CreateInvite(ctx context.Context, cmd *command.CreateListInviteCommand) (*command.CreateListInviteCommandResult, error) {
@@ -57,7 +60,7 @@ func (s *ListSharingService) CreateInvite(ctx context.Context, cmd *command.Crea
 		return nil, fmt.Errorf("%w: %s", interfaces.ErrInvalidInviteTTL, cmd.TTLKey)
 	}
 
-	if _, err := s.requireList(ctx, cmd.ListID); err != nil {
+	if err := s.requireList(ctx, cmd.ListID); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +88,7 @@ func (s *ListSharingService) CreateInvite(ctx context.Context, cmd *command.Crea
 }
 
 func (s *ListSharingService) FindActiveInvites(ctx context.Context, qry *query.GetListInvitesQuery) (*query.GetListInvitesQueryResult, error) {
-	if _, err := s.requireList(ctx, qry.ListID); err != nil {
+	if err := s.requireList(ctx, qry.ListID); err != nil {
 		return nil, err
 	}
 
@@ -143,10 +146,12 @@ func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.Rede
 		return nil, interfaces.ErrInviteNotFound
 	}
 
-	// The list may have been deleted since this invite was created; a
-	// deleted list can't be joined.
-	list, err := s.requireList(ctx, invite.ListID)
-	if err != nil {
+	// Only that the server still holds a log for this list. Whether that log
+	// ends in todo_list.deleted is not something the server can know - it
+	// doesn't read payloads - so redeeming an invite to an already-deleted
+	// list succeeds here and the client discovers the deletion on its first
+	// pull, when it rebuilds the list from full history.
+	if err := s.requireList(ctx, invite.ListID); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +165,6 @@ func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.Rede
 	} else if existing != nil {
 		return &command.RedeemListInviteCommandResult{
 			ListID:        invite.ListID,
-			ListName:      list.Name,
 			Role:          existing.Role,
 			AlreadyMember: true,
 		}, nil
@@ -185,7 +189,6 @@ func (s *ListSharingService) RedeemInvite(ctx context.Context, cmd *command.Rede
 
 	return &command.RedeemListInviteCommandResult{
 		ListID:        invite.ListID,
-		ListName:      list.Name,
 		Role:          entities.RoleMember,
 		AlreadyMember: false,
 	}, nil

--- a/backend/internal/application/services/list-sharing-service_test.go
+++ b/backend/internal/application/services/list-sharing-service_test.go
@@ -171,48 +171,36 @@ func (f *fakeListMemberRepo) FindClaimedListIDs(ctx context.Context, listIDs []u
 	return claimed, nil
 }
 
-// fakeToDoListRepo implements repositories.ToDoListRepository, but this
-// suite only ever exercises FindById - every other method panics so an
-// accidental call surfaces immediately instead of silently no-oping.
-type fakeToDoListRepo struct {
-	lists map[uuid.UUID]*entities.ToDoList
+// fakeSyncedListRepo is the registry: a set of list ids the server holds a
+// log for. No content, mirroring the real table.
+type fakeSyncedListRepo struct {
+	ids map[uuid.UUID]struct{}
 }
 
-func newFakeToDoListRepo(lists ...*entities.ToDoList) *fakeToDoListRepo {
-	m := make(map[uuid.UUID]*entities.ToDoList, len(lists))
-	for _, l := range lists {
-		m[l.Id] = l
+func newFakeSyncedListRepo(ids ...uuid.UUID) *fakeSyncedListRepo {
+	m := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		m[id] = struct{}{}
 	}
-	return &fakeToDoListRepo{lists: m}
+	return &fakeSyncedListRepo{ids: m}
 }
 
-func (f *fakeToDoListRepo) Create(context.Context, *entities.ValidatedToDoList, int64) error {
-	panic("not used by ListSharingService tests")
+func (f *fakeSyncedListRepo) Exists(_ context.Context, id uuid.UUID) (bool, error) {
+	_, ok := f.ids[id]
+	return ok, nil
 }
 
-func (f *fakeToDoListRepo) FindById(_ context.Context, id uuid.UUID) (*entities.ToDoList, error) {
-	return f.lists[id], nil
-}
-
-func (f *fakeToDoListRepo) Update(context.Context, *entities.ValidatedToDoList, int64) error {
-	panic("not used by ListSharingService tests")
-}
-
-func (f *fakeToDoListRepo) Delete(context.Context, uuid.UUID, time.Time, int64) error {
-	panic("not used by ListSharingService tests")
-}
-
-func newSharingTestService(list *entities.ToDoList) (*ListSharingService, *fakeListInviteRepo, *fakeListMemberRepo) {
+func newSharingTestService(listID uuid.UUID) (*ListSharingService, *fakeListInviteRepo, *fakeListMemberRepo) {
 	invites := newFakeListInviteRepo()
 	members := newFakeListMemberRepo()
-	todoLists := newFakeToDoListRepo(list)
+	lists := newFakeSyncedListRepo(listID)
 	access := NewListAccessService(members)
-	svc := NewListSharingService(testLogger(), invites, members, todoLists, access).(*ListSharingService)
+	svc := NewListSharingService(testLogger(), invites, members, lists, access).(*ListSharingService)
 	return svc, invites, members
 }
 
-func testList() *entities.ToDoList {
-	return &entities.ToDoList{Id: uuid.New(), Name: "Rewe"}
+func testListID() uuid.UUID {
+	return uuid.New()
 }
 
 // seedOwner simulates what the push path (ListAccessService.AuthorizeWrite,
@@ -229,76 +217,76 @@ func seedOwner(t *testing.T, members *fakeListMemberRepo, listID uuid.UUID, user
 // --- CreateInvite ---
 
 func TestListSharingService_CreateInvite_NonMemberOfUnclaimedListIsRejected(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
 
 	// Nobody has pushed to this list yet - ListSharingService itself never
 	// claims ownership anymore (see ListAccessService.AuthorizeWrite, the
 	// push path's job), so a bare CreateInvite call must not grant it.
-	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
 
-	member, err := members.FindByListAndUser(context.Background(), list.Id, "alice")
+	member, err := members.FindByListAndUser(context.Background(), listID, "alice")
 	require.NoError(t, err)
 	assert.Nil(t, member)
 }
 
 func TestListSharingService_CreateInvite_OwnerMayInvite(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "24h"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Token)
 }
 
 func TestListSharingService_CreateInvite_NonMemberOfAlreadyClaimedListIsRejected(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "mallory", TTLKey: "24h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "mallory", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
 }
 
 func TestListSharingService_CreateInvite_MemberMayNotInviteOthers(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "24h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "24h"})
 	require.NoError(t, err)
 	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 
 	// bob joined as a plain member, not the owner - sharing is owner-only.
-	_, err = svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "bob", TTLKey: "24h"})
+	_, err = svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "bob", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrNotListOwner)
 }
 
 func TestListSharingService_CreateInvite_UnknownListReturnsNotFound(t *testing.T) {
-	svc, _, _ := newSharingTestService(testList())
+	svc, _, _ := newSharingTestService(testListID())
 
 	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: uuid.New(), UserID: "alice", TTLKey: "24h"})
 	assert.ErrorIs(t, err, interfaces.ErrListNotFound)
 }
 
 func TestListSharingService_CreateInvite_InvalidTTLIsRejected(t *testing.T) {
-	list := testList()
-	svc, _, _ := newSharingTestService(list)
+	listID := testListID()
+	svc, _, _ := newSharingTestService(listID)
 
-	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "3 weeks"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "3 weeks"})
 	assert.ErrorIs(t, err, interfaces.ErrInvalidInviteTTL)
 }
 
 func TestListSharingService_CreateInvite_ExpiresAtMatchesPresetDuration(t *testing.T) {
-	list := testList()
-	svc, invites, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, invites, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
 	before := time.Now().UTC()
-	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	after := time.Now().UTC()
 
@@ -309,11 +297,11 @@ func TestListSharingService_CreateInvite_ExpiresAtMatchesPresetDuration(t *testi
 }
 
 func TestListSharingService_CreateInvite_OnlyTheTokenHashIsPersisted(t *testing.T) {
-	list := testList()
-	svc, invites, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, invites, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	result, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	stored, err := invites.FindByID(context.Background(), result.Result.ID)
@@ -323,13 +311,13 @@ func TestListSharingService_CreateInvite_OnlyTheTokenHashIsPersisted(t *testing.
 }
 
 func TestListSharingService_CreateInvite_TwoCallsProduceDifferentTokens(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	first, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	first, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
-	second, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	second, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	assert.NotEqual(t, first.Token, second.Token)
@@ -338,53 +326,53 @@ func TestListSharingService_CreateInvite_TwoCallsProduceDifferentTokens(t *testi
 // --- FindActiveInvites ---
 
 func TestListSharingService_FindActiveInvites_ExcludesExpiredAndRevoked(t *testing.T) {
-	list := testList()
-	svc, invites, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, invites, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	_, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
-	toRevoke, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	toRevoke, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	require.NoError(t, invites.Revoke(context.Background(), toRevoke.Result.ID, time.Now().UTC()))
 
 	// An invite that's already expired.
-	expired, _, err := entities.NewListInvite(list.Id, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
+	expired, _, err := entities.NewListInvite(listID, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
 	require.NoError(t, err)
 	require.NoError(t, invites.Create(context.Background(), expired))
 
-	result, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
+	result, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: listID, UserID: "alice"})
 	require.NoError(t, err)
 	require.Len(t, result.Result, 1)
 }
 
 func TestListSharingService_FindActiveInvites_DoesNotClaimOwnershipOfAnUnownedList(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
 
 	// Nobody has ever pushed to this list - it has zero members. Merely
 	// asking to list its invites must not make the caller its owner; only
 	// the push path (ListAccessService.AuthorizeWrite) may claim ownership.
-	_, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "alice"})
+	_, err := svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: listID, UserID: "alice"})
 	assert.ErrorIs(t, err, interfaces.ErrNotAListMember)
 
-	member, err := members.FindByListAndUser(context.Background(), list.Id, "alice")
+	member, err := members.FindByListAndUser(context.Background(), listID, "alice")
 	require.NoError(t, err)
 	assert.Nil(t, member)
 }
 
 func TestListSharingService_FindActiveInvites_MemberMayNotList(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
 
 	// bob is a member, not the owner - listing invites is owner-only.
-	_, err = svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: list.Id, UserID: "bob"})
+	_, err = svc.FindActiveInvites(context.Background(), &query.GetListInvitesQuery{ListID: listID, UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrNotListOwner)
 }
 
@@ -398,11 +386,11 @@ func mustTTL(t *testing.T, key string) entities.InviteTTL {
 // --- RevokeInvite ---
 
 func TestListSharingService_RevokeInvite_CreatorMayRevoke(t *testing.T) {
-	list := testList()
-	svc, invites, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, invites, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
@@ -420,14 +408,14 @@ func TestListSharingService_RevokeInvite_CreatorMayRevoke(t *testing.T) {
 // "creator OR owner" branch collapsed to "owner" (see the service).
 
 func TestListSharingService_RevokeInvite_UnrelatedMemberMayNotRevoke(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
-	member, err := entities.NewListMember(list.Id, "bob", entities.RoleMember, time.Now().UTC(), nil)
+	member, err := entities.NewListMember(listID, "bob", entities.RoleMember, time.Now().UTC(), nil)
 	require.NoError(t, err)
 	require.NoError(t, members.Add(context.Background(), member))
 
@@ -436,18 +424,18 @@ func TestListSharingService_RevokeInvite_UnrelatedMemberMayNotRevoke(t *testing.
 }
 
 func TestListSharingService_RevokeInvite_UnknownInviteReturnsNotFound(t *testing.T) {
-	svc, _, _ := newSharingTestService(testList())
+	svc, _, _ := newSharingTestService(testListID())
 
 	_, err := svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: uuid.New(), UserID: "alice"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
 }
 
 func TestListSharingService_RevokeInvite_RevokingTwiceIsIdempotent(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
@@ -459,21 +447,20 @@ func TestListSharingService_RevokeInvite_RevokingTwiceIsIdempotent(t *testing.T)
 // --- RedeemInvite ---
 
 func TestListSharingService_RedeemInvite_ValidTokenGrantsMembership(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	result, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
 	require.NoError(t, err)
-	assert.Equal(t, list.Id, result.ListID)
-	assert.Equal(t, list.Name, result.ListName)
+	assert.Equal(t, listID, result.ListID)
 	assert.Equal(t, entities.RoleMember, result.Role)
 	assert.False(t, result.AlreadyMember)
 
-	member, err := members.FindByListAndUser(context.Background(), list.Id, "bob")
+	member, err := members.FindByListAndUser(context.Background(), listID, "bob")
 	require.NoError(t, err)
 	require.NotNil(t, member)
 	require.NotNil(t, member.InviteID)
@@ -481,10 +468,10 @@ func TestListSharingService_RedeemInvite_ValidTokenGrantsMembership(t *testing.T
 }
 
 func TestListSharingService_RedeemInvite_ExpiredTokenIsRejected(t *testing.T) {
-	list := testList()
-	svc, invites, _ := newSharingTestService(list)
+	listID := testListID()
+	svc, invites, _ := newSharingTestService(listID)
 
-	expired, token, err := entities.NewListInvite(list.Id, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
+	expired, token, err := entities.NewListInvite(listID, "alice", mustTTL(t, "1h"), time.Now().UTC().Add(-2*time.Hour))
 	require.NoError(t, err)
 	require.NoError(t, invites.Create(context.Background(), expired))
 
@@ -493,11 +480,11 @@ func TestListSharingService_RedeemInvite_ExpiredTokenIsRejected(t *testing.T) {
 }
 
 func TestListSharingService_RedeemInvite_RevokedTokenIsRejected(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
@@ -507,18 +494,18 @@ func TestListSharingService_RedeemInvite_RevokedTokenIsRejected(t *testing.T) {
 }
 
 func TestListSharingService_RedeemInvite_UnknownTokenReturnsNotFound(t *testing.T) {
-	svc, _, _ := newSharingTestService(testList())
+	svc, _, _ := newSharingTestService(testListID())
 
 	_, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: "does-not-exist", UserID: "bob"})
 	assert.ErrorIs(t, err, interfaces.ErrInviteNotFound)
 }
 
 func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDuplicateMembership(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	first, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
@@ -531,7 +518,7 @@ func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDup
 
 	count := 0
 	for key := range members.members {
-		if key.listID == list.Id && key.userID == "bob" {
+		if key.listID == listID && key.userID == "bob" {
 			count++
 		}
 	}
@@ -539,11 +526,11 @@ func TestListSharingService_RedeemInvite_RedeemingTwiceIsIdempotentAndDoesNotDup
 }
 
 func TestListSharingService_RedeemInvite_RetryAfterRevokeStillSucceedsForAnExistingMember(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	first, err := svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
@@ -563,11 +550,11 @@ func TestListSharingService_RedeemInvite_RetryAfterRevokeStillSucceedsForAnExist
 }
 
 func TestListSharingService_RedeemInvite_RevokingAnInviteDoesNotRemoveExistingMembers(t *testing.T) {
-	list := testList()
-	svc, _, members := newSharingTestService(list)
-	seedOwner(t, members, list.Id, "alice")
+	listID := testListID()
+	svc, _, members := newSharingTestService(listID)
+	seedOwner(t, members, listID, "alice")
 
-	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: list.Id, UserID: "alice", TTLKey: "1h"})
+	created, err := svc.CreateInvite(context.Background(), &command.CreateListInviteCommand{ListID: listID, UserID: "alice", TTLKey: "1h"})
 	require.NoError(t, err)
 
 	_, err = svc.RedeemInvite(context.Background(), &command.RedeemListInviteCommand{Token: created.Token, UserID: "bob"})
@@ -576,7 +563,7 @@ func TestListSharingService_RedeemInvite_RevokingAnInviteDoesNotRemoveExistingMe
 	_, err = svc.RevokeInvite(context.Background(), &command.RevokeListInviteCommand{InviteID: created.Result.ID, UserID: "alice"})
 	require.NoError(t, err)
 
-	member, err := members.FindByListAndUser(context.Background(), list.Id, "bob")
+	member, err := members.FindByListAndUser(context.Background(), listID, "bob")
 	require.NoError(t, err)
 	assert.NotNil(t, member)
 }

--- a/backend/internal/domain/repositories/synced-list-repository.go
+++ b/backend/internal/domain/repositories/synced-list-repository.go
@@ -1,0 +1,15 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// SyncedListRepository answers whether the server holds a log for a list.
+// It deliberately exposes no way to read list content: the registry stores
+// none, and "does this list exist" is the only question the server needs to
+// answer about it (see frontend/docs/sync-server-registry-roadmap.md).
+type SyncedListRepository interface {
+	Exists(ctx context.Context, listID uuid.UUID) (bool, error)
+}

--- a/backend/internal/infrastructure/db/postgres/migration_00007_test.go
+++ b/backend/internal/infrastructure/db/postgres/migration_00007_test.go
@@ -18,7 +18,9 @@ import (
 // fails the moment one exists - i.e. after the very first push of any new
 // list, not some rare edge case.
 func TestMigration00007Down_SucceedsWithAListMembersRowThatHasNoTodoListsRow(t *testing.T) {
-	testDB := testhelpers.SetupTestDB(t)
+	// Pinned to 00007's own schema: a down-migration test must run against
+	// the schema that migration created, not whatever HEAD looks like today.
+	testDB := testhelpers.SetupTestDBAtMigration(t, "00007-list-access-enforcement.up.sql")
 	defer testDB.Close(t)
 
 	listID := uuid.New()
@@ -41,7 +43,9 @@ func TestMigration00007Down_SucceedsWithAListMembersRowThatHasNoTodoListsRow(t *
 // mirrors the list_members case above for list_invites, which lost the same
 // FK in the up migration for the same reason.
 func TestMigration00007Down_SucceedsWithAListInvitesRowThatHasNoTodoListsRow(t *testing.T) {
-	testDB := testhelpers.SetupTestDB(t)
+	// Pinned to 00007's own schema: a down-migration test must run against
+	// the schema that migration created, not whatever HEAD looks like today.
+	testDB := testhelpers.SetupTestDBAtMigration(t, "00007-list-access-enforcement.up.sql")
 	defer testDB.Close(t)
 
 	listID := uuid.New()
@@ -65,7 +69,9 @@ func TestMigration00007Down_SucceedsWithAListInvitesRowThatHasNoTodoListsRow(t *
 // actually put the constraints back, not just that it didn't error - a
 // dropped-and-never-restored FK would pass the two tests above too.
 func TestMigration00007Down_RestoresTheForeignKeys(t *testing.T) {
-	testDB := testhelpers.SetupTestDB(t)
+	// Pinned to 00007's own schema: a down-migration test must run against
+	// the schema that migration created, not whatever HEAD looks like today.
+	testDB := testhelpers.SetupTestDBAtMigration(t, "00007-list-access-enforcement.up.sql")
 	defer testDB.Close(t)
 
 	testDB.ApplyMigration(t, "00007-list-access-enforcement.down.sql")

--- a/backend/internal/infrastructure/db/postgres/migration_00008_test.go
+++ b/backend/internal/infrastructure/db/postgres/migration_00008_test.go
@@ -1,0 +1,159 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
+)
+
+// setupAt00007 pins these tests to the schema 00008 actually migrates from,
+// so they keep testing the backfill rather than whatever HEAD looks like.
+func setupAt00007(t *testing.T) *testhelpers.PostgresTestContainer {
+	t.Helper()
+	return testhelpers.SetupTestDBAtMigration(t, "00007-list-access-enforcement.up.sql")
+}
+
+func registryHas(t *testing.T, testDB *testhelpers.PostgresTestContainer, id uuid.UUID) bool {
+	t.Helper()
+	var exists bool
+	err := testDB.Conn.QueryRow(context.Background(),
+		`SELECT EXISTS (SELECT 1 FROM synced_lists WHERE id = $1)`, id).Scan(&exists)
+	require.NoError(t, err)
+	return exists
+}
+
+// The registry has to be backfilled from every source that can name a list
+// today, because no single one is complete: todo_lists has a row only for
+// lists whose projection succeeded, events.list_id only for lists whose
+// list_id 00004 could resolve, and list_members/list_invites can name a
+// list neither of the other two ever saw (that's exactly why 00007 had to
+// drop their foreign keys). Missing any source would leave an access row
+// orphaned and make 00008's foreign keys unaddable.
+func TestMigration00008_BackfillsTheRegistryFromEverySource(t *testing.T) {
+	testDB := setupAt00007(t)
+	defer testDB.Close(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	fromProjection := uuid.New()
+	_, err := testDB.Conn.Exec(ctx,
+		`INSERT INTO todo_lists (id, name, created_at, updated_at) VALUES ($1, 'Rewe', $2, $2)`,
+		fromProjection, now)
+	require.NoError(t, err)
+
+	fromEvents := uuid.New()
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO events (id, event_type, aggregate_id, aggregate_type, list_id, payload, occurred_at, client_id, seq)
+		 VALUES ($1, 'todo_list.created', $2, 'todo_list', $2, '{}', $3, 'client-1', 1)`,
+		uuid.New(), fromEvents, now)
+	require.NoError(t, err)
+
+	fromMembers := uuid.New()
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO list_members (list_id, user_id, role, joined_at) VALUES ($1, 'alice', 'owner', $2)`,
+		fromMembers, now)
+	require.NoError(t, err)
+
+	fromInvites := uuid.New()
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO list_invites (id, list_id, token_hash, created_by, created_at, expires_at)
+		 VALUES ($1, $2, 'hash-1', 'alice', $3::timestamptz, $3::timestamptz + interval '1 hour')`,
+		uuid.New(), fromInvites, now)
+	require.NoError(t, err)
+
+	testDB.ApplyMigration(t, "00008-list-registry.up.sql")
+
+	require.True(t, registryHas(t, testDB, fromProjection), "a list with a todo_lists row must be registered")
+	require.True(t, registryHas(t, testDB, fromEvents), "a list known only from the event log must be registered")
+	require.True(t, registryHas(t, testDB, fromMembers), "a list known only from a membership must be registered")
+	require.True(t, registryHas(t, testDB, fromInvites), "a list known only from an invite must be registered")
+}
+
+// Access rows must survive the migration untouched - unlike 00007's down,
+// which deliberately discards them, 00008 registers their list instead.
+func TestMigration00008_KeepsExistingAccessRows(t *testing.T) {
+	testDB := setupAt00007(t)
+	defer testDB.Close(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	listID := uuid.New()
+	inviteID := uuid.New()
+	_, err := testDB.Conn.Exec(ctx,
+		`INSERT INTO list_invites (id, list_id, token_hash, created_by, created_at, expires_at)
+		 VALUES ($1, $2, 'hash-1', 'alice', $3::timestamptz, $3::timestamptz + interval '1 hour')`,
+		inviteID, listID, now)
+	require.NoError(t, err)
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO list_members (list_id, user_id, role, joined_at, invite_id) VALUES ($1, 'alice', 'owner', $2, $3)`,
+		listID, now, inviteID)
+	require.NoError(t, err)
+
+	testDB.ApplyMigration(t, "00008-list-registry.up.sql")
+
+	var members, invites int
+	require.NoError(t, testDB.Conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM list_members WHERE list_id = $1`, listID).Scan(&members))
+	require.NoError(t, testDB.Conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM list_invites WHERE list_id = $1`, listID).Scan(&invites))
+	require.Equal(t, 1, members)
+	require.Equal(t, 1, invites)
+}
+
+// The point of hanging the foreign keys off the registry rather than the
+// projection: an access row for an unregistered list is now impossible,
+// which is what makes "the server knows this list" a fact rather than a
+// side effect of a projection that may or may not have been applied.
+func TestMigration00008_RejectsAccessRowsForAnUnregisteredList(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	ctx := context.Background()
+
+	_, err := testDB.Conn.Exec(ctx,
+		`INSERT INTO list_members (list_id, user_id, role, joined_at) VALUES ($1, 'alice', 'owner', NOW())`,
+		uuid.New())
+	require.Error(t, err, "a membership must not be insertable for a list the registry doesn't know")
+
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO list_invites (id, list_id, token_hash, created_by, created_at, expires_at)
+		 VALUES ($1, $2, 'hash-1', 'alice', NOW(), NOW() + interval '1 hour')`,
+		uuid.New(), uuid.New())
+	require.Error(t, err, "an invite must not be insertable for a list the registry doesn't know")
+}
+
+// Deleting the registry row is how "unsync this list" will eventually remove
+// the server copy (sync-sharing-target.md 4.4); the cascade has to carry the
+// access rows with it.
+func TestMigration00008_DeletingARegistryRowCascadesToAccessRows(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	ctx := context.Background()
+
+	listID := registerTestList(t, testDB)
+	inviteID := uuid.New()
+	_, err := testDB.Conn.Exec(ctx,
+		`INSERT INTO list_invites (id, list_id, token_hash, created_by, created_at, expires_at)
+		 VALUES ($1, $2, 'hash-1', 'alice', NOW(), NOW() + interval '1 hour')`,
+		inviteID, listID)
+	require.NoError(t, err)
+	_, err = testDB.Conn.Exec(ctx,
+		`INSERT INTO list_members (list_id, user_id, role, joined_at) VALUES ($1, 'alice', 'owner', NOW())`,
+		listID)
+	require.NoError(t, err)
+
+	_, err = testDB.Conn.Exec(ctx, `DELETE FROM synced_lists WHERE id = $1`, listID)
+	require.NoError(t, err)
+
+	var members, invites int
+	require.NoError(t, testDB.Conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM list_members WHERE list_id = $1`, listID).Scan(&members))
+	require.NoError(t, testDB.Conn.QueryRow(ctx,
+		`SELECT COUNT(*) FROM list_invites WHERE list_id = $1`, listID).Scan(&invites))
+	require.Equal(t, 0, members)
+	require.Equal(t, 0, invites)
+}

--- a/backend/internal/infrastructure/db/postgres/sqlc_list-invite-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-invite-repository_test.go
@@ -10,23 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
-	db "github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/db/sqlc"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
 )
 
-// createTestToDoList inserts a minimal todo_lists row so list_invites/
+// registerTestList inserts a minimal todo_lists row so list_invites/
 // list_members FK constraints are satisfied - shared by every test in this
 // package that needs a real list to attach sharing data to.
-func createTestToDoList(t *testing.T, testDB *testhelpers.PostgresTestContainer) uuid.UUID {
+// registerTestList makes a list id known to the server the way the real push
+// path does - a registry row, no content. Invites and memberships hang off
+// this row via the foreign keys added in 00008.
+func registerTestList(t *testing.T, testDB *testhelpers.PostgresTestContainer) uuid.UUID {
 	t.Helper()
 	id := uuid.New()
-	now := timestamptzFromTime(time.Now().UTC())
-	err := testDB.Queries.CreateToDoList(context.Background(), db.CreateToDoListParams{
-		ID:        id,
-		Name:      "Rewe",
-		CreatedAt: now,
-		UpdatedAt: now,
-	})
+	_, err := testDB.Conn.Exec(context.Background(),
+		`INSERT INTO synced_lists (id, created_at) VALUES ($1, $2)`, id, time.Now().UTC())
 	require.NoError(t, err)
 	return id
 }
@@ -36,7 +33,7 @@ func TestSqlcListInviteRepository_Create_FindByID_Roundtrips(t *testing.T) {
 	defer testDB.Close(t)
 	repo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	ttl, err := entities.ParseInviteTTL("1h")
 	require.NoError(t, err)
@@ -74,7 +71,7 @@ func TestSqlcListInviteRepository_FindByTokenHash_OnlyMatchesTheExactHash(t *tes
 	defer testDB.Close(t)
 	repo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	ttl, err := entities.ParseInviteTTL("1h")
 	require.NoError(t, err)
@@ -97,8 +94,8 @@ func TestSqlcListInviteRepository_FindActiveByList_FiltersRevokedAndExpiredAndOt
 	defer testDB.Close(t)
 	repo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
-	otherListID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
+	otherListID := registerTestList(t, testDB)
 
 	ttl, err := entities.ParseInviteTTL("1h")
 	require.NoError(t, err)
@@ -132,7 +129,7 @@ func TestSqlcListInviteRepository_Revoke_SetsRevokedAt(t *testing.T) {
 	defer testDB.Close(t)
 	repo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	ttl, err := entities.ParseInviteTTL("1h")
 	require.NoError(t, err)
@@ -154,7 +151,7 @@ func TestSqlcListInviteRepository_Revoke_TwiceIsANoOpWithoutError(t *testing.T) 
 	defer testDB.Close(t)
 	repo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	ttl, err := entities.ParseInviteTTL("1h")
 	require.NoError(t, err)

--- a/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
@@ -18,7 +18,7 @@ func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_FirstCallClaimsOwnersh
 	defer testDB.Close(t)
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, "alice", time.Now().UTC())
 	require.NoError(t, err)
@@ -36,7 +36,7 @@ func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_SecondCallDoesNotClaim
 	defer testDB.Close(t)
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, "alice", time.Now().UTC())
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestSqlcListMemberRepository_Add_InsertsMemberWithInviteID(t *testing.T) {
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	inviteRepo := NewSqlcListInviteRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	// list_members.invite_id has an FK to list_invites(id), so the invite
 	// referenced here must actually exist.
@@ -89,7 +89,7 @@ func TestSqlcListMemberRepository_Add_TwiceIsANoOpWithoutError(t *testing.T) {
 	defer testDB.Close(t)
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	first, err := entities.NewListMember(listID, "bob", entities.RoleMember, time.Now().UTC().Truncate(time.Millisecond), nil)
 	require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestSqlcListMemberRepository_FindByListAndUser_UnknownReturnsNilWithoutErro
 	testDB := testhelpers.SetupTestDB(t)
 	defer testDB.Close(t)
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	found, err := repo.FindByListAndUser(context.Background(), listID, "nobody")
 
@@ -131,7 +131,7 @@ func TestSqlcListMemberRepository_FindByListAndUser_CorruptRoleReturnsError(t *t
 	defer testDB.Close(t)
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
-	listID := createTestToDoList(t, testDB)
+	listID := registerTestList(t, testDB)
 
 	_, err := testDB.Conn.Exec(ctx, "ALTER TABLE list_members DROP CONSTRAINT list_members_role_check")
 	require.NoError(t, err)
@@ -169,8 +169,8 @@ func TestSqlcListMemberRepository_FindAccessibleListIDs_ReturnsOnlyListsTheUserI
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
 
-	own := createTestToDoList(t, testDB)
-	foreign := createTestToDoList(t, testDB)
+	own := registerTestList(t, testDB)
+	foreign := registerTestList(t, testDB)
 	unknown := uuid.New()
 
 	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, own, "alice", time.Now().UTC())
@@ -208,8 +208,8 @@ func TestSqlcListMemberRepository_FindClaimedListIDs_ReturnsListsWithAnyMemberRe
 	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
 	ctx := context.Background()
 
-	claimedByOther := createTestToDoList(t, testDB)
-	unclaimed := createTestToDoList(t, testDB)
+	claimedByOther := registerTestList(t, testDB)
+	unclaimed := registerTestList(t, testDB)
 
 	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, claimedByOther, "mallory", time.Now().UTC())
 	require.NoError(t, err)
@@ -230,4 +230,57 @@ func TestSqlcListMemberRepository_FindClaimedListIDs_EmptyInputReturnsNil(t *tes
 
 	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+// The real push path claims a list the registry has never seen - that's the
+// whole point of claim-on-first-push. Registering it has to happen in the
+// same statement as the claim, or the foreign key added in 00008 makes the
+// claim fail outright and a list could never be created at all.
+func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_RegistersAnUnknownList(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
+	registry := NewSqlcSyncedListRepository(NewQueries(testDB.Conn))
+	ctx := context.Background()
+
+	listID := uuid.New()
+	known, err := registry.Exists(ctx, listID)
+	require.NoError(t, err)
+	require.False(t, known, "precondition: the server has never seen this list")
+
+	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, "alice", time.Now().UTC())
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	known, err = registry.Exists(ctx, listID)
+	require.NoError(t, err)
+	assert.True(t, known, "claiming a list must register it in the same statement")
+}
+
+// A claim that loses the race writes no membership - and must not leave a
+// registry row behind either way, since the list is registered exactly when
+// someone owns it.
+func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_LosingClaimKeepsTheRegistryConsistent(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	repo := NewSqlcListMemberRepository(NewQueries(testDB.Conn))
+	registry := NewSqlcSyncedListRepository(NewQueries(testDB.Conn))
+	ctx := context.Background()
+
+	listID := uuid.New()
+	claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, "alice", time.Now().UTC())
+	require.NoError(t, err)
+	require.True(t, claimed)
+
+	claimed, err = repo.ClaimOwnershipIfUnowned(ctx, listID, "mallory", time.Now().UTC())
+	require.NoError(t, err)
+	require.False(t, claimed, "the list already has an owner")
+
+	known, err := registry.Exists(ctx, listID)
+	require.NoError(t, err)
+	assert.True(t, known, "the registry row stays - it belongs to alice's claim")
+
+	member, err := repo.FindByListAndUser(ctx, listID, "mallory")
+	require.NoError(t, err)
+	assert.Nil(t, member)
 }

--- a/backend/internal/infrastructure/db/postgres/sqlc_synced-list-repository.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_synced-list-repository.go
@@ -1,0 +1,25 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
+	db "github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/db/sqlc"
+)
+
+type SqlcSyncedListRepository struct {
+	queries *db.Queries
+}
+
+func NewSqlcSyncedListRepository(queries *db.Queries) repositories.SyncedListRepository {
+	return &SqlcSyncedListRepository{queries: queries}
+}
+
+// Registry rows are written by ClaimListOwnership, alongside the owner row
+// in one statement - there is deliberately no Create here, so a list can't
+// become known to the server without also becoming owned.
+func (r *SqlcSyncedListRepository) Exists(ctx context.Context, listID uuid.UUID) (bool, error) {
+	return r.queries.SyncedListExists(ctx, listID)
+}

--- a/backend/internal/infrastructure/db/sqlc/list-sharing.sql.go
+++ b/backend/internal/infrastructure/db/sqlc/list-sharing.sql.go
@@ -41,6 +41,11 @@ func (q *Queries) AddListMember(ctx context.Context, arg AddListMemberParams) er
 }
 
 const claimListOwnership = `-- name: ClaimListOwnership :one
+WITH registered AS (
+    INSERT INTO synced_lists (id, created_at)
+    VALUES ($1, $3)
+    ON CONFLICT (id) DO NOTHING
+)
 INSERT INTO list_members (list_id, user_id, role, joined_at)
 SELECT $1, $2, 'owner', $3
 WHERE NOT EXISTS (SELECT 1 FROM list_members WHERE list_id = $1)
@@ -53,11 +58,17 @@ type ClaimListOwnershipParams struct {
 	JoinedAt pgtype.Timestamptz `db:"joined_at" json:"joined_at"`
 }
 
-// Adds the caller as owner only if listID has no members yet at all - the
-// bootstrap for lists that predate this feature and never had an owner
-// recorded anywhere. NOT EXISTS and the INSERT run as one statement so the
-// common case doesn't need two round-trips. :one + zero rows (pgx.ErrNoRows)
-// means the list already had members and nothing was written.
+// Adds the caller as owner only if listID has no members yet at all, and
+// registers the list in the same statement. :one + zero rows
+// (pgx.ErrNoRows) means the list already had members and no membership was
+// written.
+//
+// The registry insert is a data-modifying CTE rather than a second
+// round-trip so the two can't diverge: Postgres runs it exactly once and to
+// completion, and list_members' foreign key is checked after the whole
+// statement, by which point the parent row exists. A member row without a
+// registry row is therefore not representable - which is what makes the
+// foreign key added in 00008 truthful rather than aspirational.
 func (q *Queries) ClaimListOwnership(ctx context.Context, arg ClaimListOwnershipParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, claimListOwnership, arg.ListID, arg.UserID, arg.JoinedAt)
 	var list_id uuid.UUID
@@ -288,4 +299,18 @@ type RevokeListInviteParams struct {
 func (q *Queries) RevokeListInvite(ctx context.Context, arg RevokeListInviteParams) error {
 	_, err := q.db.Exec(ctx, revokeListInvite, arg.RevokedAt, arg.ID)
 	return err
+}
+
+const syncedListExists = `-- name: SyncedListExists :one
+SELECT EXISTS (SELECT 1 FROM synced_lists WHERE id = $1)
+`
+
+// "Does the server hold a log for this list" - the registry replacement for
+// the old todo_lists existence check. Deliberately returns no content: the
+// server has none to return.
+func (q *Queries) SyncedListExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, syncedListExists, id)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
 }

--- a/backend/internal/infrastructure/db/sqlc/models.go
+++ b/backend/internal/infrastructure/db/sqlc/models.go
@@ -42,6 +42,11 @@ type ListMember struct {
 	InviteID pgtype.UUID        `db:"invite_id" json:"invite_id"`
 }
 
+type SyncedList struct {
+	ID        uuid.UUID          `db:"id" json:"id"`
+	CreatedAt pgtype.Timestamptz `db:"created_at" json:"created_at"`
+}
+
 type Todo struct {
 	ID          uuid.UUID          `db:"id" json:"id"`
 	Name        string             `db:"name" json:"name"`

--- a/backend/internal/infrastructure/db/sqlc/querier.go
+++ b/backend/internal/infrastructure/db/sqlc/querier.go
@@ -15,11 +15,17 @@ type Querier interface {
 	// already on (including the invite you just claimed ownership with) is a
 	// safe no-op rather than a primary key violation.
 	AddListMember(ctx context.Context, arg AddListMemberParams) error
-	// Adds the caller as owner only if listID has no members yet at all - the
-	// bootstrap for lists that predate this feature and never had an owner
-	// recorded anywhere. NOT EXISTS and the INSERT run as one statement so the
-	// common case doesn't need two round-trips. :one + zero rows (pgx.ErrNoRows)
-	// means the list already had members and nothing was written.
+	// Adds the caller as owner only if listID has no members yet at all, and
+	// registers the list in the same statement. :one + zero rows
+	// (pgx.ErrNoRows) means the list already had members and no membership was
+	// written.
+	//
+	// The registry insert is a data-modifying CTE rather than a second
+	// round-trip so the two can't diverge: Postgres runs it exactly once and to
+	// completion, and list_members' foreign key is checked after the whole
+	// statement, by which point the parent row exists. A member row without a
+	// registry row is therefore not representable - which is what makes the
+	// foreign key added in 00008 truthful rather than aspirational.
 	ClaimListOwnership(ctx context.Context, arg ClaimListOwnershipParams) (uuid.UUID, error)
 	CreateToDo(ctx context.Context, arg CreateToDoParams) (Todo, error)
 	// Projection, not an aggregate: a re-delivered created may update an
@@ -129,6 +135,10 @@ type Querier interface {
 	// revocation time - ListSharingService treats both as success either way,
 	// but this keeps the first revocation timestamp authoritative.
 	RevokeListInvite(ctx context.Context, arg RevokeListInviteParams) error
+	// "Does the server hold a log for this list" - the registry replacement for
+	// the old todo_lists existence check. Deliberately returns no content: the
+	// server has none to return.
+	SyncedListExists(ctx context.Context, id uuid.UUID) (bool, error)
 	UpdateToDo(ctx context.Context, arg UpdateToDoParams) error
 	// Missing or already-deleted row: zero rows affected, not an error - the
 	// row is a rebuildable projection, not the authority. last_applied_seq

--- a/backend/internal/interface/api/rest/dto/mapper/list-invite-response-mapper.go
+++ b/backend/internal/interface/api/rest/dto/mapper/list-invite-response-mapper.go
@@ -38,7 +38,6 @@ func ToListInviteResponseList(invites []*common.ListInviteResult) []response.Lis
 func ToRedeemListInviteResponse(result *command.RedeemListInviteCommandResult) response.RedeemListInviteResponse {
 	return response.RedeemListInviteResponse{
 		ListID:        result.ListID,
-		ListName:      result.ListName,
 		Role:          string(result.Role),
 		AlreadyMember: result.AlreadyMember,
 	}

--- a/backend/internal/interface/api/rest/dto/response/list-invite-response.go
+++ b/backend/internal/interface/api/rest/dto/response/list-invite-response.go
@@ -30,10 +30,11 @@ type ListInvitesResponse struct {
 	Invites []ListInviteResponse `json:"invites"`
 }
 
+// No list name: the server holds no list content. The client creates the
+// list locally by pulling its log from seq 0 (see sync-sharing-target.md 4.3).
 type RedeemListInviteResponse struct {
-	ListID   uuid.UUID `json:"list_id"`
-	ListName string    `json:"list_name"`
-	Role     string    `json:"role"`
+	ListID uuid.UUID `json:"list_id"`
+	Role   string    `json:"role"`
 	// AlreadyMember is true when the caller was already a member before
 	// this redeem - a successful no-op, not an error.
 	AlreadyMember bool `json:"already_member"`

--- a/backend/internal/interface/api/rest/list-sharing-controller_test.go
+++ b/backend/internal/interface/api/rest/list-sharing-controller_test.go
@@ -359,7 +359,7 @@ func TestListSharingController_RedeemInvite_ReturnsAlreadyMemberFlag(t *testing.
 			assert.Equal(t, "raw-token", cmd.Token)
 			assert.Equal(t, "user-2", cmd.UserID)
 			return &command.RedeemListInviteCommandResult{
-				ListID: listID, ListName: "Groceries", Role: entities.RoleMember, AlreadyMember: true,
+				ListID: listID, Role: entities.RoleMember, AlreadyMember: true,
 			}, nil
 		},
 	}
@@ -374,7 +374,7 @@ func TestListSharingController_RedeemInvite_ReturnsAlreadyMemberFlag(t *testing.
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.JSONEq(t,
-		`{"list_id":"`+listID.String()+`","list_name":"Groceries","role":"member","already_member":true}`,
+		`{"list_id":"`+listID.String()+`","role":"member","already_member":true}`,
 		rec.Body.String(),
 	)
 }

--- a/backend/migrations/00008-list-registry.down.sql
+++ b/backend/migrations/00008-list-registry.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE list_invites DROP CONSTRAINT list_invites_list_id_fkey;
+ALTER TABLE list_members DROP CONSTRAINT list_members_list_id_fkey;
+DROP TABLE synced_lists;

--- a/backend/migrations/00008-list-registry.up.sql
+++ b/backend/migrations/00008-list-registry.up.sql
@@ -1,0 +1,36 @@
+-- The list registry: the server's record that it holds a log for this list,
+-- with no content whatsoever. It replaces todo_lists as the answer to "does
+-- the server know this list" - a question the content projection was only
+-- ever incidentally able to answer, and could get wrong whenever its
+-- dispatch failed (see frontend/docs/sync-server-registry-roadmap.md).
+CREATE TABLE synced_lists (
+    id         UUID PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+-- Backfill from both sides, since neither alone is complete: todo_lists has
+-- rows only for lists whose todo_list.created was projected successfully,
+-- and events.list_id has rows only for lists that pushed at least one event
+-- the backfill in 00004 could resolve.
+INSERT INTO synced_lists (id, created_at)
+SELECT id, COALESCE(created_at, NOW()) FROM todo_lists
+UNION
+SELECT DISTINCT list_id, NOW() FROM events WHERE list_id IS NOT NULL
+ON CONFLICT (id) DO NOTHING;
+
+-- A member or invite can exist for a list_id no todo_lists row was ever
+-- written for - that's exactly why 00007 had to drop these FKs. Against the
+-- registry the constraint is truthful again: the row is created in the same
+-- transaction as the ownership claim, so a member without a parent is not
+-- representable. Any access row left orphaned by an earlier state gets a
+-- registry row above rather than being deleted.
+INSERT INTO synced_lists (id, created_at)
+SELECT DISTINCT list_id, NOW() FROM list_members
+UNION
+SELECT DISTINCT list_id, NOW() FROM list_invites
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE list_invites ADD CONSTRAINT list_invites_list_id_fkey
+    FOREIGN KEY (list_id) REFERENCES synced_lists(id) ON DELETE CASCADE;
+ALTER TABLE list_members ADD CONSTRAINT list_members_list_id_fkey
+    FOREIGN KEY (list_id) REFERENCES synced_lists(id) ON DELETE CASCADE;

--- a/backend/sql/queries/list-sharing.sql
+++ b/backend/sql/queries/list-sharing.sql
@@ -33,15 +33,32 @@ SET revoked_at = sqlc.arg(revoked_at)
 WHERE id = sqlc.arg(id) AND revoked_at IS NULL;
 
 -- name: ClaimListOwnership :one
--- Adds the caller as owner only if listID has no members yet at all - the
--- bootstrap for lists that predate this feature and never had an owner
--- recorded anywhere. NOT EXISTS and the INSERT run as one statement so the
--- common case doesn't need two round-trips. :one + zero rows (pgx.ErrNoRows)
--- means the list already had members and nothing was written.
+-- Adds the caller as owner only if listID has no members yet at all, and
+-- registers the list in the same statement. :one + zero rows
+-- (pgx.ErrNoRows) means the list already had members and no membership was
+-- written.
+--
+-- The registry insert is a data-modifying CTE rather than a second
+-- round-trip so the two can't diverge: Postgres runs it exactly once and to
+-- completion, and list_members' foreign key is checked after the whole
+-- statement, by which point the parent row exists. A member row without a
+-- registry row is therefore not representable - which is what makes the
+-- foreign key added in 00008 truthful rather than aspirational.
+WITH registered AS (
+    INSERT INTO synced_lists (id, created_at)
+    VALUES (sqlc.arg(list_id), sqlc.arg(joined_at))
+    ON CONFLICT (id) DO NOTHING
+)
 INSERT INTO list_members (list_id, user_id, role, joined_at)
 SELECT sqlc.arg(list_id), sqlc.arg(user_id), 'owner', sqlc.arg(joined_at)
 WHERE NOT EXISTS (SELECT 1 FROM list_members WHERE list_id = sqlc.arg(list_id))
 RETURNING list_id;
+
+-- name: SyncedListExists :one
+-- "Does the server hold a log for this list" - the registry replacement for
+-- the old todo_lists existence check. Deliberately returns no content: the
+-- server has none to return.
+SELECT EXISTS (SELECT 1 FROM synced_lists WHERE id = $1);
 
 -- name: AddListMember :exec
 -- Idempotent on (list_id, user_id) so redeeming an invite for a list you're


### PR DESCRIPTION
Roadmap-Schritt 3a aus `frontend/docs/sync-server-registry-roadmap.md`. Unabhängig von #251/#252 reviewbar.

## Warum

`todo_lists` macht heute zwei Jobs: Content-Projektion und „der Server kennt diese Liste". Nur der zweite ist echt — außerhalb der Event-Handler liest niemand den Inhalt, es bleiben ein Boolean (`requireList`) und ein String (`list_name` in der Redeem-Response).

Und für den zweiten Job war die Projektion schlecht geeignet: ihre Zeile entsteht nur, wenn der Dispatch, der sie schreibt, erfolgreich war. Eine Liste konnte also gepusht, geackt und pullbar sein, während der Server sie weiterhin für unbekannt hielt. Deshalb musste `00007` die FKs von `list_invites`/`list_members` auf `todo_lists` überhaupt droppen — sie hingen an einer Projektion, die zum Claim-Zeitpunkt noch gar nicht existiert.

## Änderungen

**`synced_lists (id, created_at)`** — eine Registry ohne jede Content-Spalte.

**Backfill aus allen vier Quellen**, die heute eine Liste benennen können. Keine ist für sich vollständig: `todo_lists` kennt nur erfolgreich projizierte Listen, `events.list_id` nur die, deren `list_id` der `00004`-Backfill auflösen konnte, und `list_members`/`list_invites` können eine Liste benennen, die keine der beiden je gesehen hat.

**FKs wieder angebaut**, diesmal gegen die Registry und mit `ON DELETE CASCADE` (Vorbedingung für `DELETE .../sync`, §4.4).

**Registry-Zeile und Owner-Zeile entstehen atomar.** Die Repos halten nur `*db.Queries`, keinen Pool. Statt dafür eine Transaktionsschicht einzuziehen, legt `ClaimListOwnership` die Registry-Zeile als daten-modifizierende CTE im *selben Statement* an: Postgres führt die garantiert genau einmal und vollständig aus, und der FK-Check feuert erst nach dem Statement. Eine Mitgliedszeile ohne Registry-Zeile ist damit nicht darstellbar — das ist es, was den FK zu einer wahren Aussage macht statt zu einer Absichtserklärung.

**`requireList`** liest die Registry und gibt keine Entität mehr zurück. `ListSharingService` hat dadurch keine `ToDoListRepository`-Abhängigkeit mehr.

**`list_name`** fällt aus der Redeem-Response. Der Client legt die Liste nach §4.3 ohnehin per Voll-Pull an; im Frontend war das Feld nachweislich ungenutzt.

## Zwei Verhaltensänderungen, die ich explizit nennen will

**Redeem auf eine gelöschte Liste gelingt jetzt.** `todo_lists.FindById` filterte `deleted_at IS NULL`; die Registry hat kein `deleted_at`. Ob ein Log in `todo_list.deleted` endet, kann der Server nur wissen, wenn er Payloads liest — und genau das soll er nicht mehr. Der Client stellt die Löschung beim ersten Voll-Pull fest, wenn er aus der Historie rebuildet, und verwirft die Liste lokal. Ein wirkungsloser Beitritt, kein Datenverlust.

**Die `00007`-Down-Tests sind an `00007`s eigenes Schema gepinnt.** Sie liefen gegen HEAD und sind an `00008` zerbrochen — zu Recht: ein Down-Test, der gegen HEAD läuft, testet ein Schema, das seine Migration nie erzeugt hat. `SetupTestDBAtMigration` gab es dafür schon.

## Was NICHT drin ist

`todo_lists`/`todos` bleiben vorerst stehen und werden weiter projiziert. Sie fallen mit dem synchronen Append (3b), zusammen mit Ingestor, Dispatcher und `ToDoListService`.

Kein Existenz-Signal in der Head-Response. Ursprünglich in der Roadmap geplant, beim Bauen als falsch erkannt: `GetHead` macht „unbekannt" und „nicht zugänglich" absichtlich ununterscheidbar, damit der Pfad kein Orakel für geratene fremde UUIDs wird. Das Signal, das §4.5 braucht, ist ohnehin „bin ich noch Mitglied", nicht „existiert die Liste" — und gehört zu `DELETE .../sync`.

## Tests

Migration: Backfill aus jeder der vier Quellen, Access-Zeilen überleben, Access-Zeile für unregistrierte Liste wird abgelehnt, Cascade beim Löschen der Registry-Zeile.
Repository: Claim registriert eine unbekannte Liste im selben Statement; ein verlorener Claim schreibt keine Mitgliedschaft und lässt die Registry konsistent.

`go build`, `go vet`, `gofmt`, `go test ./...` grün.