### PR TITLE
fix(backend): make at most one owner per list a database invariant

### DIFF
--- a/backend/internal/infrastructure/db/postgres/migration_00010_test.go
+++ b/backend/internal/infrastructure/db/postgres/migration_00010_test.go
@@ -1,0 +1,77 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
+)
+
+// setupAt00009 pins these tests to the schema 00010 actually migrates from.
+func setupAt00009(t *testing.T) *testhelpers.PostgresTestContainer {
+	t.Helper()
+	return testhelpers.SetupTestDBAtMigration(t, "00009-log-only-server.up.sql")
+}
+
+func insertListMember(
+	t *testing.T,
+	testDB *testhelpers.PostgresTestContainer,
+	listID uuid.UUID,
+	userID, role string,
+) error {
+	t.Helper()
+	_, err := testDB.Conn.Exec(context.Background(),
+		`INSERT INTO list_members (list_id, user_id, role, joined_at) VALUES ($1, $2, $3, $4)`,
+		listID, userID, role, time.Now().UTC())
+	return err
+}
+
+// A second owner row for the same list is exactly the race this migration
+// closes: idx_list_members_single_owner must reject it even though
+// list_members' primary key (list_id, user_id) doesn't, since the two rows
+// have different user_ids.
+func TestMigration00010_RejectsASecondOwnerForTheSameList(t *testing.T) {
+	testDB := setupAt00009(t)
+	defer testDB.Close(t)
+	testDB.ApplyMigration(t, "00010-single-owner-per-list.up.sql")
+
+	listID := registerTestList(t, testDB)
+	require.NoError(t, insertListMember(t, testDB, listID, "alice", "owner"))
+
+	err := insertListMember(t, testDB, listID, "bob", "owner")
+	assert.Error(t, err, "a second owner row for the same list must be rejected")
+}
+
+// The index is partial on role = 'owner', so members are unaffected -
+// a list can still have any number of member rows alongside its one owner.
+func TestMigration00010_StillAllowsMultipleMembersForTheSameList(t *testing.T) {
+	testDB := setupAt00009(t)
+	defer testDB.Close(t)
+	testDB.ApplyMigration(t, "00010-single-owner-per-list.up.sql")
+
+	listID := registerTestList(t, testDB)
+	require.NoError(t, insertListMember(t, testDB, listID, "alice", "owner"))
+
+	err := insertListMember(t, testDB, listID, "bob", "member")
+	assert.NoError(t, err, "a member row alongside the owner must still be allowed")
+}
+
+// The index is keyed on list_id, so it must not stop two different lists
+// from each having their own, independent owner.
+func TestMigration00010_StillAllowsOwnersOfDifferentLists(t *testing.T) {
+	testDB := setupAt00009(t)
+	defer testDB.Close(t)
+	testDB.ApplyMigration(t, "00010-single-owner-per-list.up.sql")
+
+	listA := registerTestList(t, testDB)
+	listB := registerTestList(t, testDB)
+	require.NoError(t, insertListMember(t, testDB, listA, "alice", "owner"))
+
+	err := insertListMember(t, testDB, listB, "bob", "owner")
+	assert.NoError(t, err, "owners of different lists must not conflict")
+}

--- a/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/repositories"
@@ -36,6 +37,16 @@ func (r *SqlcListMemberRepository) ClaimOwnershipIfUnowned(
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// The list already had members - nothing was written.
+			return false, nil
+		}
+		// A 23505 here can only come from idx_list_members_single_owner (a
+		// concurrent claim won the race between our NOT EXISTS check and
+		// our INSERT) or the list_members PK (we raced ourselves). Both
+		// mean "lost the race, nothing was written" - same as ErrNoRows -
+		// and the caller (claimNewList) already falls back to checking its
+		// own membership, so there's nothing more to do here than report it.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
 			return false, nil
 		}
 		return false, err

--- a/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
@@ -2,8 +2,6 @@ package postgres
 
 import (
 	"context"
-	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/domain/entities"
+	db "github.com/powerofcreation/simpleshoppinglistapp/internal/infrastructure/db/sqlc"
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
 )
 
@@ -287,19 +286,27 @@ func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_LosingClaimKeepsTheReg
 	assert.Nil(t, member)
 }
 
-// TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_ConcurrentClaimsProduceExactlyOneOwner
-// is the test idx_list_members_single_owner (00010) exists for: N different
-// users racing ClaimOwnershipIfUnowned for the same fresh list must yield
-// exactly one winner and zero errors - the loser's 23505 (from the index,
-// since each goroutine uses a distinct user_id so the list_members PK can't
-// be what fires) has to be swallowed into claimed=false, not surfaced.
-func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_ConcurrentClaimsProduceExactlyOneOwner(t *testing.T) {
+// TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_LoserOfADeterministicRaceLosesCleanly
+// is the regression test for idx_list_members_single_owner (00010) and the
+// 23505 mapping together. It doesn't rely on goroutine-start jitter to hit
+// the race window - a plain N-goroutine test reliably serializes instead of
+// racing, because the gap between ClaimListOwnership's NOT EXISTS check and
+// its own commit is sub-millisecond, far shorter than the time it takes a
+// second goroutine to even get scheduled. Instead it forces the exact
+// interleaving with two explicit transactions: txA claims but doesn't
+// commit, leaving an owner row that's invisible to any NOT EXISTS run from
+// outside txA; user-b's autocommit claim therefore also attempts the
+// INSERT and blocks on the unique index against txA's uncommitted key.
+// Only once txA commits does user-b's INSERT get to run - and fail with
+// 23505.
+func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_LoserOfADeterministicRaceLosesCleanly(t *testing.T) {
 	testDB := testhelpers.SetupTestDB(t)
 	defer testDB.Close(t)
 	ctx := context.Background()
 
-	// A single *pgx.Conn (testDB.Conn) is documented as unsafe for
-	// concurrent use, so this needs a real pool - see the same reasoning in
+	// A single *pgx.Conn (testDB.Conn) can't run two overlapping
+	// transactions at once, so this needs a real pool - see the same
+	// reasoning in
 	// TestSqlcEventRepository_AppendToList_ConcurrentAppendsForSameListProduceGapfreeUniqueSeq.
 	dsn := testDB.Container.(interface {
 		ConnectionString(ctx context.Context, args ...string) (string, error)
@@ -312,34 +319,46 @@ func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_ConcurrentClaimsProduc
 
 	repo := NewSqlcListMemberRepository(NewQueries(pool))
 	listID := uuid.New()
+	now := time.Now().UTC()
 
-	const concurrency = 10
-	var wg sync.WaitGroup
-	errs := make([]error, concurrency)
-	claims := make([]bool, concurrency)
+	txA, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer txA.Rollback(ctx) // safety net only - a no-op once committed below
 
-	for i := 0; i < concurrency; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, fmt.Sprintf("user-%d", idx), time.Now().UTC())
-			errs[idx] = err
-			claims[idx] = claimed
-		}(i)
+	_, err = NewQueries(pool).WithTx(txA).ClaimListOwnership(ctx, db.ClaimListOwnershipParams{
+		ListID:   listID,
+		UserID:   "user-a",
+		JoinedAt: timestamptzFromTime(now),
+	})
+	require.NoError(t, err, "txA's own claim must succeed uncommitted")
+
+	type result struct {
+		claimed bool
+		err     error
 	}
-	wg.Wait()
+	resultCh := make(chan result, 1)
+	go func() {
+		claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, "user-b", now)
+		resultCh <- result{claimed, err}
+	}()
 
-	winners := 0
-	for i, err := range errs {
-		require.NoError(t, err, "goroutine %d failed", i)
-		if claims[i] {
-			winners++
-		}
+	time.Sleep(100 * time.Millisecond) // let user-b reach and block on the index before we commit
+	require.NoError(t, txA.Commit(ctx))
+
+	select {
+	case res := <-resultCh:
+		require.NoError(t, res.err, "the loser's unique violation must be swallowed, not surfaced")
+		assert.False(t, res.claimed, "user-b must lose once user-a's claim commits")
+	case <-time.After(10 * time.Second):
+		t.Fatal("user-b's claim never returned - it's likely blocked on the index forever")
 	}
-	assert.Equal(t, 1, winners, "exactly one goroutine must win the claim")
 
 	var owners int
 	require.NoError(t, pool.QueryRow(ctx,
 		`SELECT COUNT(*) FROM list_members WHERE list_id = $1 AND role = 'owner'`, listID).Scan(&owners))
-	assert.Equal(t, 1, owners, "exactly one owner row must exist in the database")
+	assert.Equal(t, 1, owners, "exactly one owner row must exist")
+
+	owner, err := repo.FindByListAndUser(ctx, listID, "user-a")
+	require.NoError(t, err)
+	require.NotNil(t, owner, "the committed claim (user-a) must be the one that stuck")
 }

--- a/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-member-repository_test.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -283,4 +285,61 @@ func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_LosingClaimKeepsTheReg
 	member, err := repo.FindByListAndUser(ctx, listID, "mallory")
 	require.NoError(t, err)
 	assert.Nil(t, member)
+}
+
+// TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_ConcurrentClaimsProduceExactlyOneOwner
+// is the test idx_list_members_single_owner (00010) exists for: N different
+// users racing ClaimOwnershipIfUnowned for the same fresh list must yield
+// exactly one winner and zero errors - the loser's 23505 (from the index,
+// since each goroutine uses a distinct user_id so the list_members PK can't
+// be what fires) has to be swallowed into claimed=false, not surfaced.
+func TestSqlcListMemberRepository_ClaimOwnershipIfUnowned_ConcurrentClaimsProduceExactlyOneOwner(t *testing.T) {
+	testDB := testhelpers.SetupTestDB(t)
+	defer testDB.Close(t)
+	ctx := context.Background()
+
+	// A single *pgx.Conn (testDB.Conn) is documented as unsafe for
+	// concurrent use, so this needs a real pool - see the same reasoning in
+	// TestSqlcEventRepository_AppendToList_ConcurrentAppendsForSameListProduceGapfreeUniqueSeq.
+	dsn := testDB.Container.(interface {
+		ConnectionString(ctx context.Context, args ...string) (string, error)
+	})
+	connString, err := dsn.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+	pool, err := NewConnection(ctx, connString)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	repo := NewSqlcListMemberRepository(NewQueries(pool))
+	listID := uuid.New()
+
+	const concurrency = 10
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	claims := make([]bool, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			claimed, err := repo.ClaimOwnershipIfUnowned(ctx, listID, fmt.Sprintf("user-%d", idx), time.Now().UTC())
+			errs[idx] = err
+			claims[idx] = claimed
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d failed", i)
+		if claims[i] {
+			winners++
+		}
+	}
+	assert.Equal(t, 1, winners, "exactly one goroutine must win the claim")
+
+	var owners int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM list_members WHERE list_id = $1 AND role = 'owner'`, listID).Scan(&owners))
+	assert.Equal(t, 1, owners, "exactly one owner row must exist in the database")
 }

--- a/backend/migrations/00005-list-sharing.up.sql
+++ b/backend/migrations/00005-list-sharing.up.sql
@@ -34,12 +34,6 @@ CREATE TABLE list_members (
     PRIMARY KEY (list_id, user_id)
 );
 
--- Deliberately no unique index enforcing "at most one owner per list" here.
--- claim-on-first-invite is a bootstrap for lists that predate this feature
--- and predate any ownership model at all; it will be superseded once list
--- creation itself records an owner from the verified JWT (planned
--- tenant/user-isolation work). Two concurrent first-invites under READ
--- COMMITTED could in theory both insert an owner row, but that grants
--- neither party anything they don't already have today (knowing a list's
--- UUID already means full read/write access) - not worth a constraint that
--- would need its own migration to relax once co-owners become a real case.
+-- "At most one owner per list" is enforced by a partial unique index added
+-- later, in 00010, once ownership became the access boundary itself rather
+-- than a label on top of an already-open list.

--- a/backend/migrations/00010-single-owner-per-list.down.sql
+++ b/backend/migrations/00010-single-owner-per-list.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_list_members_single_owner;

--- a/backend/migrations/00010-single-owner-per-list.up.sql
+++ b/backend/migrations/00010-single-owner-per-list.up.sql
@@ -1,0 +1,4 @@
+-- ClaimListOwnership's NOT EXISTS subquery isn't an exclusion under READ
+-- COMMITTED: two concurrent first-claims can both pass it before either
+-- commits, giving a list two owners. This index makes it one.
+CREATE UNIQUE INDEX idx_list_members_single_owner ON list_members (list_id) WHERE role = 'owner';


### PR DESCRIPTION
## Problem

`ClaimListOwnership` beansprucht eine noch mitgliederlose Liste per
`INSERT ... SELECT ... WHERE NOT EXISTS (SELECT 1 FROM list_members WHERE list_id = ...)`,
ausgeführt als einzelnes Autocommit-Statement aus `ListAccessService.claimNewList`.

Unter READ COMMITTED sieht ein `NOT EXISTS`-Subquery die noch nicht committete Zeile einer
parallelen Transaktion nicht. `list_members` hat PK `(list_id, user_id)` — nichts verhindert
also, dass zwei **verschiedene** Nutzer beide eine `role = 'owner'`-Zeile für dieselbe Liste
einfügen. Zwei gleichzeitige Erst-Pushes auf dieselbe, noch niemandem gehörende Listen-UUID
machen beide zum Owner.

Migration `00005` dokumentiert das als bewusst akzeptiert, mit der Begründung, es gewähre
niemandem etwas, das er nicht ohnehin hätte („knowing a list's UUID already means full
read/write access"). Diese Begründung ist seit #249/#253 überholt: Ownership **ist** jetzt die
Zugriffsgrenze, und nur der Owner darf Invite-Links erzeugen und widerrufen.

## Fix

- Migration `00010`: partieller Unique-Index `list_members (list_id) WHERE role = 'owner'`.
  Macht aus dem `NOT EXISTS` einen echten Ausschluss.
- `ClaimOwnershipIfUnowned` behandelt SQLSTATE `23505` genauso wie `pgx.ErrNoRows`, also als
  „Race verloren, nichts geschrieben" (`claimed = false, err = nil`). Der Aufrufer
  `claimNewList` hat dafür bereits den Fallback „bin ich selbst Mitglied?" und gibt sonst 403.
  Ein 23505 kann aus diesem Statement nur vom neuen Index oder vom `list_members`-PK kommen —
  beides heißt „Race verloren".
- Der überholte Kommentarblock in `00005` verweist jetzt auf `00010`; am SQL dort nichts geändert.

## Tests

- `migration_00010_test.go`: zweite Owner-Zeile abgelehnt, zweite `member`-Zeile weiterhin
  erlaubt, Owner verschiedener Listen weiterhin erlaubt.
- `ClaimOwnershipIfUnowned_LoserOfADeterministicRaceLosesCleanly`: erzwingt das Interleaving
  mit zwei expliziten Transaktionen statt Goroutine-Racing. `txA` beansprucht die Liste und
  committet nicht; der Autocommit-Claim von `user-b` sieht die unsichtbare Zeile nicht,
  versucht den INSERT und blockiert am Unique-Index; nach `txA.Commit` muss `user-b` sauber
  mit `claimed == false, err == nil` verlieren.

  Ein naiver N-Goroutinen-Test taugt hier nicht — er besteht auch ohne den Fix, weil das
  Fenster zwischen `NOT EXISTS` und Commit unter einer Millisekunde liegt und die Goroutinen
  sich faktisch serialisieren. Gegenprobe mit zurückgesetztem Fix: der neue Test schlägt an
  beiden Hälften fehl (`user-b` gewinnt, zwei Owner-Zeilen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjzXTcCC2t9YAqxRvTZtte