### PR TITLE
fix(backend): report a missing payload as such, not as invalid JSON

### DIFF
--- a/backend/internal/interface/api/rest/event-controller.go
+++ b/backend/internal/interface/api/rest/event-controller.go
@@ -195,8 +195,8 @@ func distinctListIDs(events []request.SyncEventRequest) ([]uuid.UUID, error) {
 // check without parsing payload content: event_id/aggregate_id must be
 // real UUIDs, a todo_list.* event's aggregate_id must equal its own
 // list_id (list_id itself is already required by distinctListIDs, called
-// before this), payload must be syntactically valid JSON, and both
-// per-event and per-batch payload size stay bounded. It deliberately never
+// before this), payload must be present and syntactically valid JSON, and
+// both per-event and per-batch payload size stay bounded. It deliberately never
 // looks at a field inside payload - an unknown event_type or a semantically
 // invalid payload (e.g. an empty name) is not this function's concern, see
 // SyncEvents's doc comment.
@@ -214,6 +214,9 @@ func validateEventStructure(events []request.SyncEventRequest) error {
 		}
 		if len(event.Payload) > maxEventPayloadBytes {
 			return fmt.Errorf("event %s: payload exceeds %d bytes", event.EventID, maxEventPayloadBytes)
+		}
+		if len(event.Payload) == 0 {
+			return fmt.Errorf("event %s: payload is required", event.EventID)
 		}
 		if !json.Valid(event.Payload) {
 			return fmt.Errorf("event %s: payload is not valid JSON", event.EventID)

--- a/backend/internal/interface/api/rest/event-controller_test.go
+++ b/backend/internal/interface/api/rest/event-controller_test.go
@@ -357,6 +357,7 @@ func TestEventController_SyncEvents_MissingPayloadReturns400(t *testing.T) {
 	e.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "payload is required", "the message must say the payload is missing, not that it's invalid JSON")
 	assert.NotContains(t, repo.seen, eventID, "a structurally invalid event must not reach the events table")
 }
 


### PR DESCRIPTION
## Summary
- `json.Valid(nil)` returns `false`, so a request that omits `payload` entirely hit the same "payload is not valid JSON" message as truly malformed JSON.
- `validateEventStructure` now checks for a missing payload first and returns a distinct "payload is required" message.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/interface/api/rest/...` (all pass, including the strengthened `TestEventController_SyncEvents_MissingPayloadReturns400`)
- [x] `go vet ./...`, `gofmt -l` clean