### PR TITLE
fix(frontend): validate completed/completedAt types in ingredient events

### DIFF
--- a/frontend/database/__tests__/ingredient-projection.test.ts
+++ b/frontend/database/__tests__/ingredient-projection.test.ts
@@ -158,6 +158,46 @@ describe("IngredientProjection", () => {
       )
       expect(row).toEqual({ name: "Whole Milk", completed: 1 })
     })
+
+    it("skips (doesn't throw) when completed has the wrong type", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(
+          db,
+          makeEvent({
+            payload: JSON.stringify({ name: "Milk", completed: "yes" }),
+          })
+        )
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(`SELECT id FROM ingredients`)
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it("skips (doesn't throw) when completedAt has the wrong type", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleCreated(
+          db,
+          makeEvent({
+            payload: JSON.stringify({
+              name: "Milk",
+              completed: true,
+              completedAt: "not-a-timestamp",
+            }),
+          })
+        )
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync(`SELECT id FROM ingredients`)
+      expect(row).toBeNull()
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
   })
 
   describe("handleUpdated", () => {
@@ -226,6 +266,55 @@ describe("IngredientProjection", () => {
         completed_at: number | null
       }>(`SELECT completed, completed_at FROM ingredients WHERE id = 'ing-1'`)
       expect(row).toEqual({ completed: 0, completed_at: null })
+    })
+
+    it("skips (doesn't throw) when completed has the wrong type", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleUpdated(
+          db,
+          makeEvent({
+            event_type: EventTypes.INGREDIENT_UPDATED,
+            occurred_at: 3000,
+            payload: JSON.stringify({ completed: "yes", completedAt: 3000 }),
+          })
+        )
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync<{
+        completed: number
+        updated_at: number
+      }>(`SELECT completed, updated_at FROM ingredients WHERE id = 'ing-1'`)
+      expect(row).toEqual({ completed: 0, updated_at: 1000 })
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it("skips (doesn't throw) when completedAt has the wrong type", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation()
+
+      await expect(
+        projection.handleUpdated(
+          db,
+          makeEvent({
+            event_type: EventTypes.INGREDIENT_UPDATED,
+            occurred_at: 3000,
+            payload: JSON.stringify({
+              completed: true,
+              completedAt: "not-a-timestamp",
+            }),
+          })
+        )
+      ).resolves.toBeUndefined()
+
+      const row = await db.getFirstAsync<{
+        completed: number
+        updated_at: number
+      }>(`SELECT completed, updated_at FROM ingredients WHERE id = 'ing-1'`)
+      expect(row).toEqual({ completed: 0, updated_at: 1000 })
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
     })
   })
 

--- a/frontend/database/ingredient-projection.ts
+++ b/frontend/database/ingredient-projection.ts
@@ -10,8 +10,8 @@ const logger = createLogger("IngredientProjection")
 
 type CreatedPayload = {
   name: string
-  completed?: unknown
-  completedAt?: unknown
+  completed?: boolean
+  completedAt?: number | null
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -19,7 +19,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isCreatedPayload(value: unknown): value is CreatedPayload {
-  return isRecord(value) && typeof value.name === "string"
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    (value.completed === undefined || typeof value.completed === "boolean") &&
+    (value.completedAt === undefined ||
+      value.completedAt === null ||
+      typeof value.completedAt === "number")
+  )
 }
 
 function isPrioritySetPayload(value: unknown): value is { priority: number } {
@@ -105,7 +112,7 @@ export class IngredientProjection {
       event.list_id,
       event.occurred_at,
       event.occurred_at,
-      (payload.completedAt as number | null | undefined) ?? null
+      payload.completedAt ?? null
     )
   }
 
@@ -128,11 +135,23 @@ export class IngredientProjection {
         event.aggregate_id
       )
     } else {
+      if (
+        typeof payload.completed !== "boolean" ||
+        (payload.completedAt !== null &&
+          typeof payload.completedAt !== "number")
+      ) {
+        this.logSkipped(
+          event,
+          "payload.completed/completedAt has the wrong type",
+          onSkip
+        )
+        return
+      }
       await db.runAsync(
         `UPDATE ingredients SET completed = ?, updated_at = ?, completed_at = ? WHERE id = ?`,
         payload.completed ? 1 : 0,
         event.occurred_at,
-        (payload.completedAt as number | null | undefined) ?? null,
+        payload.completedAt,
         event.aggregate_id
       )
     }


### PR DESCRIPTION
## Summary
- `isCreatedPayload` only validated `name`; `completed`/`completedAt` stayed typed `unknown` and were passed through unvalidated (`payload.completed ? 1 : 0` coerces any truthy value, and `completedAt` was written via an `as` cast).
- `handleUpdated`'s completed-update branch had the same gap: no type check on `completed`/`completedAt` before writing.
- Both now use real type guards (`completed: boolean`, `completedAt: number | null`) and skip (logged, per R4) on a type mismatch instead of silently miscoercing.

## Test plan
- [x] Added 4 tests: wrong-type `completed`/`completedAt` in both `handleCreated` and `handleUpdated`
- [x] `pnpm test` (491/491 pass)
- [x] `pnpm tsc --noEmit`, `pnpm lint` clean