### PR TITLE
fix(backend): correct stale synced_lists registry comments

### DIFF
--- a/backend/internal/infrastructure/db/postgres/sqlc_list-invite-repository_test.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_list-invite-repository_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/powerofcreation/simpleshoppinglistapp/internal/testhelpers"
 )
 
-// registerTestList inserts a minimal todo_lists row so list_invites/
-// list_members FK constraints are satisfied - shared by every test in this
-// package that needs a real list to attach sharing data to.
 // registerTestList makes a list id known to the server the way the real push
 // path does - a registry row, no content. Invites and memberships hang off
 // this row via the foreign keys added in 00008.

--- a/backend/internal/infrastructure/db/postgres/sqlc_synced-list-repository.go
+++ b/backend/internal/infrastructure/db/postgres/sqlc_synced-list-repository.go
@@ -19,7 +19,9 @@ func NewSqlcSyncedListRepository(queries *db.Queries) repositories.SyncedListRep
 
 // Registry rows are written by ClaimListOwnership, alongside the owner row
 // in one statement - there is deliberately no Create here, so a list can't
-// become known to the server without also becoming owned.
+// become known to the server without also becoming owned. The one exception
+// is the 00008 backfill, which seeded synced_lists for lists that predate
+// the registry and may have no owner membership.
 func (r *SqlcSyncedListRepository) Exists(ctx context.Context, listID uuid.UUID) (bool, error) {
 	return r.queries.SyncedListExists(ctx, listID)
 }


### PR DESCRIPTION
## Summary
- `SqlcSyncedListRepository.Exists`'s doc comment claimed "a list can't become known to the server without also becoming owned" - true going forward, but migration `00008` backfills `synced_lists` from pre-registry sources with no owner membership. Qualified the comment to note that exception.
- `registerTestList`'s doc comment was duplicated - two back-to-back blocks, the first stale ("inserts a minimal todo_lists row") from before the table was renamed to `synced_lists`. Deleted the stale block.

## Test plan
- [x] `go build ./...`, `gofmt -l` clean
- [x] `go test ./internal/infrastructure/db/postgres/... -run TestSqlcListInviteRepository` (real Postgres via testcontainers, all pass)