### PR TITLE
ci(backend): fail lint if go.sum/go.mod aren't tidy

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -36,3 +36,7 @@ jobs:
       - name: 🏃‍♂️ Run go vet
         run: go vet ./...
         working-directory: ./backend
+
+      - name: 🏃‍♂️ Check go.mod/go.sum are tidy
+        run: go mod tidy -diff
+        working-directory: ./backend

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -5,10 +5,12 @@ on:
     branches: [main, master]
     paths:
       - "backend/**"
+      - ".github/workflows/backend-lint.yml"
   pull_request:
     branches: [main, master]
     paths:
       - "backend/**"
+      - ".github/workflows/backend-lint.yml"
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Adds a `go mod tidy -diff` step to the backend lint workflow so a drifting `go.sum`/`go.mod` fails CI instead of going unnoticed.
- Prompted by PR #264, where `go.sum` on `main` had accumulated stale hash entries from earlier dependency bumps that were never `tidy`'d — no CI step caught it, and it only got cleaned up as an incidental side effect of a Copilot fix commit there.

## Note
`main`'s `go.sum` is currently untidy, so this check will fail until PR #264 (which happens to fix it) merges — or `go mod tidy` is run separately on `backend/` first.

## Test plan
- [x] `go mod tidy -diff` locally reproduces the same failure `main` currently has
- [ ] CI run on this PR (expected to fail until #264 merges or go.sum is tidied)