### PR TITLE
feat(frontend): let a list owner manage invite links from the app

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -128,6 +128,25 @@ lists after a reinstall (pull only ever fetches lists already known and
 sync-enabled locally) and user-scoping on the backend (see
 `docs/sync-design-decisions.md`).
 
+### Sharing a list (invite links)
+
+A list this device syncs can be shared from its context menu ("Invite
+people"), which opens `app/(home)/share_shopping_list.tsx`: it lists the
+list's active invite links, creates a new one with a server-side validity
+preset (1h / 24h / 7d / 30d) and revokes existing ones, all through
+`api/sharing/sharing-client.ts`. Only the owner may do any of this — that is
+enforced by the backend and shown here as an error message, because the
+client has no endpoint yet to ask what its own role is.
+
+The link itself is built on the device (`api/sharing/invite-link.ts`) as
+`<app scheme>://invite?token=…` — the backend never learns a frontend route,
+so it only ever hands out the raw token, exactly once, in the response that
+created the invite. It cannot be fetched again afterwards; only its hash is
+stored. **Redeeming is not implemented yet**: nothing in the app handles that
+deep link, so an invited person cannot join through it so far. The same goes
+for showing who has already joined — that needs a backend endpoint that does
+not exist yet (see `docs/sync-sharing-target.md` §5).
+
 `.env.development` points at `http://10.0.2.2:8080`, the Android emulator's
 alias for the host machine's localhost, so `pnpm android:dev` talks to a
 backend running locally via `docker compose up -d postgres && go run

--- a/frontend/api/common/error-types.ts
+++ b/frontend/api/common/error-types.ts
@@ -113,3 +113,39 @@ export class SyncError extends AppError {
     super(message)
   }
 }
+
+/**
+ * What went wrong while managing a list's invite links.
+ *
+ * Unlike SyncError, "can I retry this" is rarely the interesting question:
+ * sharing happens in a screen a person is looking at, and every failure mode
+ * is one they can act on - sign in again, push the list once so the server
+ * knows it, or accept that they are not its owner. `kind` carries that
+ * distinction, mapped from the statuses ListSharingController returns (see
+ * sharing-client.ts's errorForStatus).
+ */
+export type SharingErrorKind =
+  /** 401 - no valid session; the token expired or was revoked. */
+  | "unauthenticated"
+  /** 403 - the caller is a member, not the owner, of this list. */
+  | "notOwner"
+  /** 404 on a list - no log on the server, so it can't be shared yet. */
+  | "listUnknown"
+  /** 404/410 on an invite - already revoked, expired, or gone. */
+  | "inviteGone"
+  /** 400 - the request itself was rejected (e.g. an unknown TTL preset). */
+  | "invalid"
+  /** Timeout or transport failure; nothing is known about the outcome. */
+  | "network"
+  /** 5xx or an unreadable response body. */
+  | "server"
+
+export class SharingError extends AppError {
+  constructor(
+    message: string,
+    public kind: SharingErrorKind,
+    public originalError?: unknown
+  ) {
+    super(message)
+  }
+}

--- a/frontend/api/sharing/__tests__/invite-link.test.ts
+++ b/frontend/api/sharing/__tests__/invite-link.test.ts
@@ -1,0 +1,45 @@
+import { buildInviteLink, INVITE_PATH } from "../invite-link"
+import { getRedirectScheme } from "@/api/auth/redirect-uri"
+
+jest.mock("@/api/auth/redirect-uri", () => ({
+  getRedirectScheme: jest.fn(),
+}))
+const mockGetRedirectScheme = getRedirectScheme as jest.Mock
+
+describe("buildInviteLink", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("builds a deep link from the app's own scheme", () => {
+    mockGetRedirectScheme.mockReturnValue("de.lightdevsolutions.sholist.dev")
+
+    expect(buildInviteLink("token-1")).toBe(
+      `de.lightdevsolutions.sholist.dev://${INVITE_PATH}?token=token-1`
+    )
+  })
+
+  // The scheme comes from the running binary, so a dev build never hands out
+  // a link that would open the production app.
+  it("uses whatever scheme the running build reports", () => {
+    mockGetRedirectScheme.mockReturnValue("de.lightdevsolutions.sholist")
+
+    expect(buildInviteLink("token-1")).toContain(
+      "de.lightdevsolutions.sholist://"
+    )
+  })
+
+  it("escapes tokens containing url-unsafe characters", () => {
+    mockGetRedirectScheme.mockReturnValue("app.test")
+
+    expect(buildInviteLink("a+b/c=")).toBe(
+      `app.test://${INVITE_PATH}?token=a%2Bb%2Fc%3D`
+    )
+  })
+
+  it("returns null when no scheme is available", () => {
+    mockGetRedirectScheme.mockReturnValue(null)
+
+    expect(buildInviteLink("token-1")).toBeNull()
+  })
+})

--- a/frontend/api/sharing/__tests__/sharing-client.test.ts
+++ b/frontend/api/sharing/__tests__/sharing-client.test.ts
@@ -1,0 +1,223 @@
+import { SharingClient } from "../sharing-client"
+import { Result } from "@/api/common/result"
+
+import { getValidAccessToken } from "@/api/auth/auth-service"
+
+jest.mock("@/api/auth/auth-service", () => ({
+  getValidAccessToken: jest.fn(),
+}))
+const mockGetValidAccessToken = getValidAccessToken as jest.Mock
+
+const jsonResponse = (status: number, body: unknown) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const emptyResponse = (status: number) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => {
+    throw new Error("no body")
+  },
+})
+
+describe("SharingClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetValidAccessToken.mockResolvedValue(Result.ok("valid-token"))
+  })
+
+  describe("getInvites", () => {
+    it("requests the list's invites and maps the wire shape", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse(200, {
+          invites: [
+            {
+              invite_id: "invite-1",
+              created_by: "user-1",
+              created_at: "2026-08-20T10:00:00Z",
+              expires_at: "2026-08-27T10:00:00Z",
+            },
+          ],
+        })
+      )
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.success).toBe(true)
+      expect(result.getValue()).toEqual([
+        {
+          inviteId: "invite-1",
+          createdBy: "user-1",
+          createdAt: Date.parse("2026-08-20T10:00:00Z"),
+          expiresAt: Date.parse("2026-08-27T10:00:00Z"),
+        },
+      ])
+
+      const [url, options] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/v1/todo-lists/list-1/invites")
+      expect(options.method).toBe("GET")
+      expect(options.headers.Authorization).toBe("Bearer valid-token")
+    })
+
+    it("keeps an invite whose timestamps are unreadable, without a date", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse(200, {
+          invites: [
+            {
+              invite_id: "invite-1",
+              created_by: "user-1",
+              created_at: "not-a-date",
+              expires_at: null,
+            },
+          ],
+        })
+      )
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.getValue()).toEqual([
+        {
+          inviteId: "invite-1",
+          createdBy: "user-1",
+          createdAt: null,
+          expiresAt: null,
+        },
+      ])
+    })
+
+    it("returns an empty list when the body has no invites array", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(200, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.success).toBe(true)
+      expect(result.getValue()).toEqual([])
+    })
+
+    // 404 on a list means the server holds no log for it yet, which is
+    // fixable by syncing - quite unlike a 404 on an invite.
+    it("maps a 404 on a list to listUnknown", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(404, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.success).toBe(false)
+      expect(result.getError().kind).toBe("listUnknown")
+    })
+
+    it("maps a 403 to notOwner", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(403, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.getError().kind).toBe("notOwner")
+    })
+
+    it("maps a transport failure to a network error", async () => {
+      const fetchMock = jest.fn().mockRejectedValue(new Error("offline"))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.getError().kind).toBe("network")
+    })
+
+    it("fails without hitting the network when not signed in", async () => {
+      mockGetValidAccessToken.mockResolvedValue(Result.ok(null))
+      const fetchMock = jest.fn()
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.getInvites("list-1")
+
+      expect(result.getError().kind).toBe("unauthenticated")
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("createInvite", () => {
+    it("posts the chosen ttl and returns the one-time token", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse(201, {
+          invite_id: "invite-1",
+          list_id: "list-1",
+          token: "plaintext-token",
+          created_at: "2026-08-20T10:00:00Z",
+          expires_at: "2026-08-21T10:00:00Z",
+        })
+      )
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.createInvite("list-1", "24h")
+
+      expect(result.success).toBe(true)
+      expect(result.getValue()).toEqual({
+        inviteId: "invite-1",
+        listId: "list-1",
+        token: "plaintext-token",
+        createdAt: Date.parse("2026-08-20T10:00:00Z"),
+        expiresAt: Date.parse("2026-08-21T10:00:00Z"),
+      })
+
+      const [url, options] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/v1/todo-lists/list-1/invites")
+      expect(options.method).toBe("POST")
+      expect(options.headers["Content-Type"]).toBe("application/json")
+      expect(JSON.parse(options.body)).toEqual({ ttl: "24h" })
+    })
+
+    // A created invite without a readable token is unusable: the plaintext
+    // exists nowhere else. Better an explicit failure than a screen showing
+    // "undefined" as a link.
+    it("fails when the response carries no token", async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue(jsonResponse(201, { invite_id: "invite-1" }))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.createInvite("list-1", "24h")
+
+      expect(result.success).toBe(false)
+      expect(result.getError().kind).toBe("server")
+    })
+
+    it("maps a rejected ttl to an invalid request", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(400, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.createInvite("list-1", "24h")
+
+      expect(result.getError().kind).toBe("invalid")
+    })
+  })
+
+  describe("revokeInvite", () => {
+    it("deletes the invite and succeeds on the empty 204 body", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(emptyResponse(204))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.revokeInvite("invite-1")
+
+      expect(result.success).toBe(true)
+
+      const [url, options] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/v1/invites/invite-1")
+      expect(options.method).toBe("DELETE")
+    })
+
+    it("maps a 404 on an invite to inviteGone, not listUnknown", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(404, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.revokeInvite("invite-1")
+
+      expect(result.getError().kind).toBe("inviteGone")
+    })
+  })
+})

--- a/frontend/api/sharing/config.ts
+++ b/frontend/api/sharing/config.ts
@@ -1,0 +1,27 @@
+import { isSyncConfigured, syncConfig } from "@/api/sync/config"
+
+/**
+ * Sharing lives on the same backend as sync and is configured by the same
+ * EXPO_PUBLIC_API_URL - there is no separate switch. It is re-exported under
+ * its own name so the sharing screens read as what they are ("is sharing
+ * available") instead of reaching into sync's config for an answer that only
+ * incidentally comes from there.
+ */
+export const isSharingConfigured = isSyncConfigured
+
+/**
+ * The `todo-lists` path segment is historical: the table of that name no
+ * longer exists, the route addresses a list id in the server's registry (see
+ * frontend/docs/sync-sharing-target.md §5). Renaming it is a client-breaking
+ * change and is deliberately not done here.
+ */
+export const sharingConfig = {
+  listInvitesUrl(listId: string): string {
+    const base = syncConfig.apiBaseUrl
+    return `${base}/api/v1/todo-lists/${encodeURIComponent(listId)}/invites`
+  },
+  inviteUrl(inviteId: string): string {
+    const base = syncConfig.apiBaseUrl
+    return `${base}/api/v1/invites/${encodeURIComponent(inviteId)}`
+  },
+}

--- a/frontend/api/sharing/invite-link.ts
+++ b/frontend/api/sharing/invite-link.ts
@@ -1,0 +1,36 @@
+import { getRedirectScheme } from "@/api/auth/redirect-uri"
+
+/**
+ * The deep-link path an invite points at. Redeeming is not implemented yet -
+ * nothing in the app navigates here (see the note in
+ * frontend/docs/sync-sharing-target.md §5) - but the link the owner shares
+ * has to be built now, and its shape is what a future redeem handler will
+ * have to match.
+ */
+export const INVITE_PATH = "invite"
+
+/** Query parameter carrying the plaintext invite token. */
+export const INVITE_TOKEN_PARAM = "token"
+
+/**
+ * Builds the shareable link for a freshly created invite token.
+ *
+ * The link is assembled here rather than returned by the backend on purpose:
+ * the server never learns a frontend route (sync-sharing-target.md §4.3), so
+ * the app owns the mapping from token to URL. The scheme is the app's
+ * reverse-DNS scheme, the same one the OIDC redirect uses - which means a dev
+ * build produces a dev link and a release build a release one, without either
+ * having to know about the other.
+ *
+ * Returns null when the scheme can't be determined (web, where there is no
+ * application id). Callers must handle that rather than shipping a link that
+ * opens nothing.
+ */
+export function buildInviteLink(token: string): string | null {
+  const scheme = getRedirectScheme()
+  if (!scheme) {
+    return null
+  }
+  const encodedToken = encodeURIComponent(token)
+  return `${scheme}://${INVITE_PATH}?${INVITE_TOKEN_PARAM}=${encodedToken}`
+}

--- a/frontend/api/sharing/sharing-client.ts
+++ b/frontend/api/sharing/sharing-client.ts
@@ -1,0 +1,325 @@
+import { getValidAccessToken } from "@/api/auth/auth-service"
+import { createLogger } from "@/api/common/logger"
+import { Result } from "@/api/common/result"
+import { SharingError, SharingErrorKind } from "@/api/common/error-types"
+import { sharingConfig } from "./config"
+
+const logger = createLogger("SharingClient")
+
+const REQUEST_TIMEOUT_MS = 10000
+
+/**
+ * The validity presets the backend accepts. Not free-form: the server
+ * validates against exactly this list (entities.ParseInviteTTL) and answers
+ * anything else with 400, so offering a different value in the UI could only
+ * ever produce an error.
+ */
+export const INVITE_TTLS = ["1h", "24h", "7d", "30d"] as const
+
+export type InviteTTL = (typeof INVITE_TTLS)[number]
+
+/**
+ * An active invite as the *listing* endpoint returns it - deliberately
+ * without a token. The plaintext exists exactly once, in the create
+ * response; only its hash is stored (sync-sharing-target.md §4.3). An
+ * existing link can therefore be revoked but never shown again.
+ */
+export type ListInvite = {
+  inviteId: string
+  createdBy: string
+  createdAt: number | null
+  expiresAt: number | null
+}
+
+/** The create response - the only shape that ever carries a token. */
+export type CreatedInvite = {
+  inviteId: string
+  listId: string
+  token: string
+  createdAt: number | null
+  expiresAt: number | null
+}
+
+export type FetchLike = typeof fetch
+
+type WireInvite = {
+  invite_id?: unknown
+  created_by?: unknown
+  created_at?: unknown
+  expires_at?: unknown
+}
+
+type WireCreatedInvite = WireInvite & {
+  list_id?: unknown
+  token?: unknown
+}
+
+/**
+ * The sharing DTOs carry Go `time.Time` values, i.e. RFC 3339 strings -
+ * unlike the sync wire shapes, where occurred_at is epoch ms.
+ *
+ * Anything unparseable becomes null rather than NaN or a 1970 date: an
+ * invite whose timestamps we cannot read is still a live link the owner may
+ * want to revoke, so it has to survive into the list - just without a date.
+ */
+function parseTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") {
+    return null
+  }
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * 404 means two different things depending on what was addressed, and the
+ * two have opposite remedies: a list the server doesn't know yet needs one
+ * successful push, while an invite it doesn't know is simply gone. `subject`
+ * is which of the two the request was about.
+ */
+function errorForStatus(
+  status: number,
+  subject: "list" | "invite"
+): SharingError {
+  const map: Record<number, [string, SharingErrorKind]> = {
+    400: ["The server rejected the request", "invalid"],
+    401: ["Your session is no longer valid", "unauthenticated"],
+    403: ["Only the owner of this list can manage its invites", "notOwner"],
+    404:
+      subject === "list"
+        ? ["The server does not know this list yet", "listUnknown"]
+        : ["This invite no longer exists", "inviteGone"],
+    410: ["This invite is no longer valid", "inviteGone"],
+  }
+  const known = map[status]
+  if (known) {
+    return new SharingError(known[0], known[1])
+  }
+  return new SharingError(`Unexpected response status ${status}`, "server")
+}
+
+type RequestSpec = {
+  url: string
+  method: "GET" | "POST" | "DELETE"
+  body?: string
+  subject: "list" | "invite"
+  networkErrorMessage: string
+}
+
+/**
+ * Manages a list's invite links over REST. Every route here is owner-only
+ * server-side; the client cannot know its own role up front (there is no
+ * membership endpoint yet, see sync-sharing-target.md §5), so a non-owner
+ * finds out through a "notOwner" SharingError rather than a hidden button.
+ */
+export class SharingClient {
+  constructor(private readonly fetchImpl: FetchLike = fetch) {}
+
+  private async getAuthToken(): Promise<Result<string, SharingError>> {
+    const tokenResult = await getValidAccessToken()
+    if (!tokenResult.success) {
+      // Reaching here means the refresh itself failed - an expired or
+      // revoked refresh token (see auth-service.refreshSession), not a
+      // request that could be retried into working.
+      return Result.fail(
+        new SharingError(
+          "Could not refresh your session",
+          "unauthenticated",
+          tokenResult.getError()
+        )
+      )
+    }
+    const token = tokenResult.getValue()
+    if (!token) {
+      return Result.fail(
+        new SharingError("You are not signed in", "unauthenticated")
+      )
+    }
+    return Result.ok(token)
+  }
+
+  /**
+   * One authenticated request under REQUEST_TIMEOUT_MS, with every non-2xx
+   * already mapped to a SharingError. Callers only deal with a Response they
+   * know is successful.
+   */
+  private async request(
+    spec: RequestSpec
+  ): Promise<Result<Response, SharingError>> {
+    const tokenResult = await this.getAuthToken()
+    if (!tokenResult.success) {
+      return Result.fail(tokenResult.getError())
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${tokenResult.getValue()}`,
+    }
+    if (spec.body !== undefined) {
+      headers["Content-Type"] = "application/json"
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await this.fetchImpl(spec.url, {
+        method: spec.method,
+        headers,
+        body: spec.body,
+        signal: controller.signal,
+      })
+    } catch (error) {
+      logger.warn(spec.networkErrorMessage, error)
+      return Result.fail(
+        new SharingError(spec.networkErrorMessage, "network", error)
+      )
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    if (!response.ok) {
+      return Result.fail(errorForStatus(response.status, spec.subject))
+    }
+    return Result.ok(response)
+  }
+
+  private async parseJson(
+    response: Response,
+    what: string
+  ): Promise<Result<unknown, SharingError>> {
+    try {
+      return Result.ok(await response.json())
+    } catch (error) {
+      logger.warn(`Could not read the ${what} response body`, error)
+      return Result.fail(
+        new SharingError(
+          `The server's ${what} response was unreadable`,
+          "server",
+          error
+        )
+      )
+    }
+  }
+
+  /**
+   * The list's currently active invites, newest first - the server orders by
+   * created_at DESC (GetActiveListInvites) and this preserves that order
+   * rather than imposing a second one. Revoked and expired invites are
+   * filtered out server-side, so everything returned here is a link that
+   * still works.
+   */
+  async getInvites(
+    listId: string
+  ): Promise<Result<ListInvite[], SharingError>> {
+    const responseResult = await this.request({
+      url: sharingConfig.listInvitesUrl(listId),
+      method: "GET",
+      subject: "list",
+      networkErrorMessage: "Network error while loading invite links",
+    })
+    if (!responseResult.success) {
+      return Result.fail(responseResult.getError())
+    }
+
+    const bodyResult = await this.parseJson(
+      responseResult.getValue()!,
+      "invite list"
+    )
+    if (!bodyResult.success) {
+      return Result.fail(bodyResult.getError())
+    }
+
+    const body = bodyResult.getValue() as { invites?: WireInvite[] }
+    const invites = Array.isArray(body?.invites) ? body.invites : []
+    return Result.ok(
+      invites.flatMap((invite) =>
+        typeof invite?.invite_id === "string"
+          ? [
+              {
+                inviteId: invite.invite_id,
+                createdBy:
+                  typeof invite.created_by === "string"
+                    ? invite.created_by
+                    : "",
+                createdAt: parseTimestamp(invite.created_at),
+                expiresAt: parseTimestamp(invite.expires_at),
+              },
+            ]
+          : []
+      )
+    )
+  }
+
+  /**
+   * Creates a multi-use invite link valid for `ttl`.
+   *
+   * The token in the response cannot be fetched again later, so a body that
+   * doesn't parse is a real (if rare) loss: the invite exists server-side but
+   * its link is gone. That surfaces as a "server" error, and the invite shows
+   * up in the next getInvites() call - tokenless, and revocable.
+   */
+  async createInvite(
+    listId: string,
+    ttl: InviteTTL
+  ): Promise<Result<CreatedInvite, SharingError>> {
+    const responseResult = await this.request({
+      url: sharingConfig.listInvitesUrl(listId),
+      method: "POST",
+      body: JSON.stringify({ ttl }),
+      subject: "list",
+      networkErrorMessage: "Network error while creating an invite link",
+    })
+    if (!responseResult.success) {
+      return Result.fail(responseResult.getError())
+    }
+
+    const bodyResult = await this.parseJson(
+      responseResult.getValue()!,
+      "created invite"
+    )
+    if (!bodyResult.success) {
+      return Result.fail(bodyResult.getError())
+    }
+
+    const body = bodyResult.getValue() as WireCreatedInvite
+    if (typeof body?.token !== "string" || typeof body.invite_id !== "string") {
+      return Result.fail(
+        new SharingError(
+          "The server did not return a usable invite link",
+          "server"
+        )
+      )
+    }
+
+    return Result.ok({
+      inviteId: body.invite_id,
+      listId: typeof body.list_id === "string" ? body.list_id : listId,
+      token: body.token,
+      createdAt: parseTimestamp(body.created_at),
+      expiresAt: parseTimestamp(body.expires_at),
+    })
+  }
+
+  /**
+   * Revokes an invite. The server answers 204 and treats revoking an
+   * already-revoked invite as a no-op, so this is safe to retry.
+   */
+  async revokeInvite(inviteId: string): Promise<Result<void, SharingError>> {
+    const responseResult = await this.request({
+      url: sharingConfig.inviteUrl(inviteId),
+      method: "DELETE",
+      subject: "invite",
+      networkErrorMessage: "Network error while revoking the invite link",
+    })
+    if (!responseResult.success) {
+      return Result.fail(responseResult.getError())
+    }
+    return Result.ok<void, SharingError>(null)
+  }
+}
+
+/**
+ * Shared instance for the screens. Sharing is a plain request/response
+ * feature with no background state, so it needs neither a provider nor the
+ * lifecycle SyncEngine has.
+ */
+export const sharingClient = new SharingClient()

--- a/frontend/app/(home)/__tests__/share_shopping_list-test.tsx
+++ b/frontend/app/(home)/__tests__/share_shopping_list-test.tsx
@@ -80,7 +80,7 @@ describe("ShareShoppingList", () => {
     mockBuildInviteLink.mockReturnValue("app.test://invite?token=plaintext")
   })
 
-  it("shows the list it is about and loads its active invites", async () => {
+  it("loads the active invites for the given list", async () => {
     mockGetInvites.mockResolvedValue(Result.ok([anInvite()]))
 
     renderShareScreen()
@@ -89,7 +89,6 @@ describe("ShareShoppingList", () => {
       expect(screen.getByTestId("invite-entry-invite-1")).toBeTruthy()
     })
     expect(mockGetInvites).toHaveBeenCalledWith("list-1")
-    expect(screen.getByTestId("share-list-name")).toHaveTextContent("Rewe")
   })
 
   it("explains the empty state instead of showing nothing", async () => {

--- a/frontend/app/(home)/__tests__/share_shopping_list-test.tsx
+++ b/frontend/app/(home)/__tests__/share_shopping_list-test.tsx
@@ -1,0 +1,280 @@
+import { Share, type ShareAction } from "react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { renderRouter } from "expo-router/testing-library"
+
+import ShareShoppingList from "../share_shopping_list"
+import { Result } from "@/api/common/result"
+import { SharingError } from "@/api/common/error-types"
+import { useAuth } from "@/api/auth/AuthProvider"
+import { sharingClient } from "@/api/sharing/sharing-client"
+import { buildInviteLink } from "@/api/sharing/invite-link"
+
+jest.mock("@/api/auth/AuthProvider")
+
+// The client itself is covered by sharing-client.test.ts; here it stands in
+// for the backend so the screen's own behaviour is what's under test.
+jest.mock("@/api/sharing/sharing-client", () => {
+  const actual = jest.requireActual("@/api/sharing/sharing-client")
+  return {
+    ...actual,
+    sharingClient: {
+      getInvites: jest.fn(),
+      createInvite: jest.fn(),
+      revokeInvite: jest.fn(),
+    },
+  }
+})
+
+jest.mock("@/api/sharing/invite-link", () => ({
+  ...jest.requireActual("@/api/sharing/invite-link"),
+  buildInviteLink: jest.fn(),
+}))
+
+const mockedUseAuth = useAuth as jest.Mock
+const mockGetInvites = sharingClient.getInvites as jest.Mock
+const mockCreateInvite = sharingClient.createInvite as jest.Mock
+const mockRevokeInvite = sharingClient.revokeInvite as jest.Mock
+const mockBuildInviteLink = buildInviteLink as jest.Mock
+
+function mockAuth(status: "loading" | "signedIn" | "signedOut") {
+  mockedUseAuth.mockReturnValue({
+    status,
+    user: null,
+    error: null,
+    busy: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+  })
+}
+
+const anInvite = (overrides: Record<string, unknown> = {}) => ({
+  inviteId: "invite-1",
+  createdBy: "user-1",
+  createdAt: Date.now() - 60_000,
+  expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+  ...overrides,
+})
+
+function renderShareScreen() {
+  return renderRouter(
+    { share_shopping_list: ShareShoppingList },
+    { initialUrl: "/share_shopping_list?listId=list-1&listName=Rewe" }
+  )
+}
+
+describe("ShareShoppingList", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAuth("signedIn")
+    mockGetInvites.mockResolvedValue(Result.ok([]))
+    mockCreateInvite.mockResolvedValue(
+      Result.ok({
+        inviteId: "invite-2",
+        listId: "list-1",
+        token: "plaintext-token",
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 60 * 60 * 1000,
+      })
+    )
+    mockRevokeInvite.mockResolvedValue(Result.ok(null))
+    mockBuildInviteLink.mockReturnValue("app.test://invite?token=plaintext")
+  })
+
+  it("shows the list it is about and loads its active invites", async () => {
+    mockGetInvites.mockResolvedValue(Result.ok([anInvite()]))
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invite-entry-invite-1")).toBeTruthy()
+    })
+    expect(mockGetInvites).toHaveBeenCalledWith("list-1")
+    expect(screen.getByTestId("share-list-name")).toHaveTextContent("Rewe")
+  })
+
+  it("explains the empty state instead of showing nothing", async () => {
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invites-empty")).toBeTruthy()
+    })
+  })
+
+  // Sharing needs a session; asking the backend without one could only
+  // produce a 401 dressed up as an error message.
+  it("asks the user to sign in and stays off the network when signed out", async () => {
+    mockAuth("signedOut")
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("share-unavailable")).toBeTruthy()
+    })
+    expect(mockGetInvites).not.toHaveBeenCalled()
+  })
+
+  it("creates a link with the selected validity preset", async () => {
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invites-empty")).toBeTruthy()
+    })
+
+    fireEvent.press(screen.getByTestId("invite-ttl-1h"))
+    fireEvent.press(screen.getByTestId("create-invite"))
+
+    await waitFor(() => {
+      expect(mockCreateInvite).toHaveBeenCalledWith("list-1", "1h")
+    })
+  })
+
+  it("defaults to the 7 day preset", async () => {
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invites-empty")).toBeTruthy()
+    })
+
+    fireEvent.press(screen.getByTestId("create-invite"))
+
+    await waitFor(() => {
+      expect(mockCreateInvite).toHaveBeenCalledWith("list-1", "7d")
+    })
+  })
+
+  // The plaintext token exists exactly once, in this response - so the
+  // screen has to show it, and say that it won't come back.
+  it("shows the new link once, with a warning that it cannot be recovered", async () => {
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invites-empty")).toBeTruthy()
+    })
+
+    fireEvent.press(screen.getByTestId("create-invite"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("new-invite-link")).toHaveTextContent(
+        "app.test://invite?token=plaintext"
+      )
+    })
+    expect(screen.getByText(/cannot be recovered/i)).toBeTruthy()
+
+    fireEvent.press(screen.getByTestId("dismiss-invite"))
+    await waitFor(() => {
+      expect(screen.queryByTestId("new-invite-card")).toBeNull()
+    })
+  })
+
+  it("hands the link to the system share sheet", async () => {
+    const shareSpy = jest
+      .spyOn(Share, "share")
+      .mockResolvedValue({ action: "sharedAction" } as ShareAction)
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invites-empty")).toBeTruthy()
+    })
+    fireEvent.press(screen.getByTestId("create-invite"))
+    await waitFor(() => {
+      expect(screen.getByTestId("share-invite")).toBeTruthy()
+    })
+
+    fireEvent.press(screen.getByTestId("share-invite"))
+
+    await waitFor(() => {
+      expect(shareSpy).toHaveBeenCalledWith({
+        message: "app.test://invite?token=plaintext",
+      })
+    })
+    shareSpy.mockRestore()
+  })
+
+  it("revokes a link only after the confirmation is accepted", async () => {
+    mockGetInvites.mockResolvedValue(Result.ok([anInvite()]))
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invite-revoke-invite-1")).toBeTruthy()
+    })
+
+    fireEvent.press(screen.getByTestId("invite-revoke-invite-1"))
+    expect(mockRevokeInvite).not.toHaveBeenCalled()
+
+    fireEvent.press(
+      screen.getByTestId("invite-revoke-confirm-invite-1-confirm")
+    )
+
+    await waitFor(() => {
+      expect(mockRevokeInvite).toHaveBeenCalledWith("invite-1")
+    })
+  })
+
+  // A revoke the server refuses must not look like one that worked: the row
+  // stays, so something has to say why.
+  it("reports a revoke the server refused", async () => {
+    mockGetInvites.mockResolvedValue(Result.ok([anInvite()]))
+    mockRevokeInvite.mockResolvedValue(
+      Result.fail(new SharingError("nope", "notOwner"))
+    )
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("invite-revoke-invite-1")).toBeTruthy()
+    })
+    fireEvent.press(screen.getByTestId("invite-revoke-invite-1"))
+    fireEvent.press(
+      screen.getByTestId("invite-revoke-confirm-invite-1-confirm")
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("share-error")).toBeTruthy()
+    })
+  })
+
+  // Ownership is enforced server-side and there is no membership endpoint to
+  // ask beforehand, so a member has to learn it from the answer.
+  it("explains a 403 as not being the list's owner", async () => {
+    mockGetInvites.mockResolvedValue(
+      Result.fail(new SharingError("nope", "notOwner"))
+    )
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("share-error")).toHaveTextContent(
+        /only the owner/i
+      )
+    })
+  })
+
+  // "No active invite links" next to "you are not the owner" would read as
+  // two different answers to the same question.
+  it("does not claim there are no links when the load failed", async () => {
+    mockGetInvites.mockResolvedValue(
+      Result.fail(new SharingError("nope", "notOwner"))
+    )
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("share-error")).toBeTruthy()
+    })
+    expect(screen.queryByTestId("invites-empty")).toBeNull()
+  })
+
+  it("waits for the session to be restored before judging it", async () => {
+    mockAuth("loading")
+
+    renderShareScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("share-auth-loading")).toBeTruthy()
+    })
+    expect(screen.queryByTestId("share-unavailable")).toBeNull()
+    expect(mockGetInvites).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/(home)/_layout.tsx
+++ b/frontend/app/(home)/_layout.tsx
@@ -49,6 +49,12 @@ export default function HomeLayout() {
           headerTitle: "New list",
         }}
       />
+      <Stack.Screen
+        name="share_shopping_list"
+        options={{
+          headerTitle: "Invite people",
+        }}
+      />
     </Stack>
   )
 }

--- a/frontend/app/(home)/index.tsx
+++ b/frontend/app/(home)/index.tsx
@@ -106,6 +106,19 @@ export default function Index() {
     }
   }
 
+  const handleShareList = (id: string) => {
+    const list = lists.find((l) => l.id === id)
+    if (!list) return
+
+    // The name travels as a param so the invite screen can show which list
+    // it is talking about without another query - it never needs the list's
+    // content, only its id.
+    router.push({
+      pathname: "/share_shopping_list",
+      params: { listId: id, listName: list.name },
+    })
+  }
+
   const handleResync = async (id: string) => {
     try {
       await syncEngine.repairList(id)
@@ -131,6 +144,7 @@ export default function Index() {
         onToggleSync={(enabled) => handleToggleSync(item.id, enabled)}
         syncToggleDisabled={!isSignedIn}
         onResync={() => handleResync(item.id)}
+        onShare={() => handleShareList(item.id)}
       />
     )
   }

--- a/frontend/app/(home)/share_shopping_list.tsx
+++ b/frontend/app/(home)/share_shopping_list.tsx
@@ -1,0 +1,374 @@
+import React from "react"
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Share,
+  StyleSheet,
+  View,
+} from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { useLocalSearchParams } from "expo-router"
+
+import { useAuth } from "@/api/auth/AuthProvider"
+import { createLogger } from "@/api/common/logger"
+import { isSharingConfigured } from "@/api/sharing/config"
+import { buildInviteLink } from "@/api/sharing/invite-link"
+import { INVITE_TTLS, InviteTTL } from "@/api/sharing/sharing-client"
+import { InviteEntry } from "@/components/InviteEntry"
+import { PrimaryButton } from "@/components/PrimaryButton"
+import { ThemedText } from "@/components/ThemedText"
+import { useListInvites } from "@/hooks/useListInvites"
+import { useThemeColor } from "@/hooks/useThemeColor"
+import { formatInviteTtl } from "@/utils/inviteFormatting"
+
+const logger = createLogger("ShareShoppingList")
+
+const DEFAULT_TTL: InviteTTL = "7d"
+
+/**
+ * Invite management for one synchronized list.
+ *
+ * Reachable only from a list this device syncs while signed in (see the
+ * context menu in ShoppingListEntry): sharing needs a list the server
+ * actually holds a log for, and the server only learns of one through a
+ * push (sync-sharing-target.md §4.2). Being the owner is enforced server
+ * side and surfaces here as an error, because the client has no way to ask
+ * for its own role yet - GET /todo-lists/:id/membership is still open (§5).
+ */
+export default function ShareShoppingList() {
+  const { listId, listName } = useLocalSearchParams<{
+    listId: string
+    listName: string
+  }>()
+  const { status } = useAuth()
+  const isSignedIn = status === "signedIn"
+  const configured = isSharingConfigured()
+  const canManageInvites = Boolean(listId) && isSignedIn && configured
+
+  const [selectedTtl, setSelectedTtl] = React.useState<InviteTTL>(DEFAULT_TTL)
+
+  const {
+    invites,
+    now,
+    isLoading,
+    errorMessage,
+    createInvite,
+    isCreating,
+    newInvite,
+    dismissNewInvite,
+    revokeInvite,
+    revokingInviteId,
+  } = useListInvites(listId, canManageInvites)
+
+  const backgroundColor = useThemeColor({}, "background")
+  const surfaceColor = useThemeColor({}, "surface")
+  const dividerColor = useThemeColor({}, "divider")
+  const accentColor = useThemeColor({}, "accent")
+  const onAccentColor = useThemeColor({}, "onAccent")
+  const textSecondaryColor = useThemeColor({}, "textSecondary")
+  const dangerColor = useThemeColor({}, "danger")
+
+  const inviteLink = newInvite ? buildInviteLink(newInvite.token) : null
+
+  const handleShare = React.useCallback(async () => {
+    if (!inviteLink) return
+    try {
+      await Share.share({ message: inviteLink })
+    } catch (error) {
+      // A dismissed share sheet is not a failure worth showing.
+      logger.warn("Could not open the share sheet", error)
+    }
+  }, [inviteLink])
+
+  const renderUnavailable = (message: string) => (
+    <ThemedText
+      testID="share-unavailable"
+      style={[styles.hint, { color: textSecondaryColor }]}
+    >
+      {message}
+    </ThemedText>
+  )
+
+  const renderInvites = () => {
+    if (isLoading) {
+      return (
+        <ActivityIndicator
+          testID="invites-loading"
+          size="small"
+          style={styles.loader}
+        />
+      )
+    }
+
+    // A failed load leaves `invites` empty, and "no active links" stacked on
+    // top of "you are not the owner" reads as two different answers to the
+    // same question. The error below is the answer.
+    if (errorMessage) {
+      return null
+    }
+
+    if (invites.length === 0) {
+      return (
+        <ThemedText
+          testID="invites-empty"
+          style={[styles.hint, { color: textSecondaryColor }]}
+        >
+          No active invite links. Create one below to let someone join this
+          list.
+        </ThemedText>
+      )
+    }
+
+    return invites.map((invite) => (
+      <InviteEntry
+        key={invite.inviteId}
+        inviteId={invite.inviteId}
+        createdAt={invite.createdAt}
+        expiresAt={invite.expiresAt}
+        now={now}
+        revoking={revokingInviteId === invite.inviteId}
+        onRevoke={() => revokeInvite(invite.inviteId)}
+      />
+    ))
+  }
+
+  const renderContent = () => {
+    if (!listId) {
+      return renderUnavailable("No list selected.")
+    }
+    if (!configured) {
+      return renderUnavailable(
+        "Sharing needs a backend. Set EXPO_PUBLIC_API_URL to enable it."
+      )
+    }
+    // Restoring the session is not "signed out" - saying so would flash the
+    // wrong answer on every cold start.
+    if (status === "loading") {
+      return (
+        <ActivityIndicator
+          testID="share-auth-loading"
+          size="small"
+          style={styles.loader}
+        />
+      )
+    }
+    if (!isSignedIn) {
+      return renderUnavailable(
+        "Sign in to invite people to a list you synchronize."
+      )
+    }
+
+    return (
+      <>
+        <View style={styles.section}>
+          <ThemedText type="subtitle">People with access</ThemedText>
+          <ThemedText
+            testID="share-members-placeholder"
+            style={[styles.hint, { color: textSecondaryColor }]}
+          >
+            You own this list. Everyone who opens an active link below joins as
+            a member and can view and edit it - they cannot invite anyone else.
+            Showing who has joined needs a backend endpoint that does not exist
+            yet.
+          </ThemedText>
+        </View>
+
+        <View style={[styles.divider, { backgroundColor: dividerColor }]} />
+
+        <View style={styles.section}>
+          <ThemedText type="subtitle">Active invite links</ThemedText>
+          {renderInvites()}
+        </View>
+
+        <View style={[styles.divider, { backgroundColor: dividerColor }]} />
+
+        <View style={styles.section}>
+          <ThemedText type="subtitle">New invite link</ThemedText>
+          <ThemedText style={[styles.hint, { color: textSecondaryColor }]}>
+            A link can be used by more than one person until it expires.
+          </ThemedText>
+          <View style={styles.ttlRow}>
+            {INVITE_TTLS.map((ttl) => {
+              const isSelected = ttl === selectedTtl
+              return (
+                <Pressable
+                  key={ttl}
+                  testID={`invite-ttl-${ttl}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: isSelected }}
+                  onPress={() => setSelectedTtl(ttl)}
+                  style={[
+                    styles.ttlChip,
+                    {
+                      borderColor: isSelected ? accentColor : dividerColor,
+                      backgroundColor: isSelected
+                        ? accentColor
+                        : backgroundColor,
+                    },
+                  ]}
+                >
+                  <ThemedText
+                    style={[
+                      styles.ttlLabel,
+                      isSelected ? { color: onAccentColor } : undefined,
+                    ]}
+                  >
+                    {formatInviteTtl(ttl)}
+                  </ThemedText>
+                </Pressable>
+              )
+            })}
+          </View>
+          <PrimaryButton
+            testID="create-invite"
+            label="Create invite link"
+            loading={isCreating}
+            onPress={() => createInvite(selectedTtl)}
+          />
+        </View>
+
+        {newInvite ? (
+          <View
+            testID="new-invite-card"
+            style={[styles.card, { backgroundColor: surfaceColor }]}
+          >
+            <ThemedText type="defaultSemiBold">Your new link</ThemedText>
+            <ThemedText
+              testID="new-invite-link"
+              selectable
+              style={[styles.link, { color: accentColor }]}
+            >
+              {inviteLink ?? newInvite.token}
+            </ThemedText>
+            <ThemedText style={[styles.hint, { color: textSecondaryColor }]}>
+              {inviteLink
+                ? "This link is shown once and cannot be recovered later. Share it now; you can revoke it above at any time."
+                : "This device cannot build a link, so here is the raw token. It is shown once and cannot be recovered later."}
+            </ThemedText>
+            <View style={styles.cardActions}>
+              {inviteLink ? (
+                <PrimaryButton
+                  testID="share-invite"
+                  label="Share link"
+                  onPress={handleShare}
+                />
+              ) : null}
+              <Pressable
+                testID="dismiss-invite"
+                accessibilityRole="button"
+                onPress={dismissNewInvite}
+                style={styles.dismissButton}
+              >
+                <ThemedText style={{ color: textSecondaryColor }}>
+                  Done
+                </ThemedText>
+              </Pressable>
+            </View>
+          </View>
+        ) : null}
+
+        {errorMessage ? (
+          <ThemedText
+            testID="share-error"
+            style={[styles.error, { color: dangerColor }]}
+          >
+            {errorMessage}
+          </ThemedText>
+        ) : null}
+      </>
+    )
+  }
+
+  return (
+    <SafeAreaView
+      testID="share-shopping-list-screen"
+      edges={["bottom"]}
+      style={[styles.container, { backgroundColor }]}
+    >
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {listName ? (
+          <ThemedText
+            testID="share-list-name"
+            style={[styles.listName, { color: textSecondaryColor }]}
+          >
+            {listName}
+          </ThemedText>
+        ) : null}
+        {renderContent()}
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    gap: 4,
+  },
+  listName: {
+    fontSize: 13,
+    marginBottom: 8,
+  },
+  section: {
+    gap: 8,
+    paddingVertical: 8,
+  },
+  divider: {
+    height: 1,
+    marginVertical: 8,
+  },
+  hint: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  loader: {
+    alignSelf: "flex-start",
+    marginVertical: 8,
+  },
+  ttlRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  ttlChip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  ttlLabel: {
+    fontSize: 14,
+  },
+  card: {
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 12,
+    gap: 8,
+  },
+  link: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  cardActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginTop: 4,
+  },
+  dismissButton: {
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+  },
+  error: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: 12,
+  },
+})

--- a/frontend/app/(home)/share_shopping_list.tsx
+++ b/frontend/app/(home)/share_shopping_list.tsx
@@ -37,7 +37,7 @@ const DEFAULT_TTL: InviteTTL = "7d"
  * for its own role yet - GET /todo-lists/:id/membership is still open (§5).
  */
 export default function ShareShoppingList() {
-  const { listId, listName } = useLocalSearchParams<{
+  const { listId } = useLocalSearchParams<{
     listId: string
     listName: string
   }>()
@@ -290,14 +290,6 @@ export default function ShareShoppingList() {
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        {listName ? (
-          <ThemedText
-            testID="share-list-name"
-            style={[styles.listName, { color: textSecondaryColor }]}
-          >
-            {listName}
-          </ThemedText>
-        ) : null}
         {renderContent()}
       </ScrollView>
     </SafeAreaView>
@@ -311,10 +303,6 @@ const styles = StyleSheet.create({
   content: {
     padding: 20,
     gap: 4,
-  },
-  listName: {
-    fontSize: 13,
-    marginBottom: 8,
   },
   section: {
     gap: 8,

--- a/frontend/components/InviteEntry.tsx
+++ b/frontend/components/InviteEntry.tsx
@@ -1,0 +1,111 @@
+import React from "react"
+import { ActivityIndicator, Pressable, StyleSheet, View } from "react-native"
+
+import { ThemedText } from "./ThemedText"
+import { ConfirmDialog } from "./ConfirmDialog"
+import { useThemeColor } from "@/hooks/useThemeColor"
+import {
+  formatInviteCreatedAt,
+  formatInviteExpiry,
+} from "@/utils/inviteFormatting"
+
+export type InviteEntryProps = {
+  inviteId: string
+  createdAt: number | null
+  expiresAt: number | null
+  /** Reference time for the relative expiry - see formatInviteExpiry. */
+  now: number
+  revoking?: boolean
+  onRevoke: () => void
+}
+
+/**
+ * One active invite link.
+ *
+ * There is deliberately no way to show or re-copy the link itself: the
+ * plaintext token exists only in the response that created it
+ * (sync-sharing-target.md §4.3). What is left afterwards is what this row
+ * offers - see when it was made, when it dies on its own, and end it early.
+ */
+export function InviteEntry(props: InviteEntryProps) {
+  const [showRevokeConfirm, setShowRevokeConfirm] = React.useState(false)
+
+  const dividerColor = useThemeColor({}, "divider")
+  const textSecondaryColor = useThemeColor({}, "textSecondary")
+  const dangerColor = useThemeColor({}, "danger")
+
+  return (
+    <>
+      <View
+        testID={`invite-entry-${props.inviteId}`}
+        style={[styles.row, { borderBottomColor: dividerColor }]}
+      >
+        <View style={styles.info}>
+          <ThemedText type="defaultSemiBold" style={styles.expiry}>
+            {formatInviteExpiry(props.expiresAt, props.now)}
+          </ThemedText>
+          <ThemedText style={[styles.created, { color: textSecondaryColor }]}>
+            {formatInviteCreatedAt(props.createdAt)}
+          </ThemedText>
+        </View>
+        {props.revoking ? (
+          <ActivityIndicator
+            testID={`invite-revoking-${props.inviteId}`}
+            size="small"
+          />
+        ) : (
+          <Pressable
+            testID={`invite-revoke-${props.inviteId}`}
+            accessibilityRole="button"
+            accessibilityLabel="Revoke invite link"
+            onPress={() => setShowRevokeConfirm(true)}
+            style={styles.revokeButton}
+          >
+            <ThemedText style={[styles.revokeLabel, { color: dangerColor }]}>
+              Revoke
+            </ThemedText>
+          </Pressable>
+        )}
+      </View>
+      <ConfirmDialog
+        testID={`invite-revoke-confirm-${props.inviteId}`}
+        visible={showRevokeConfirm}
+        title="Revoke this link?"
+        message="Anyone who still has this link will no longer be able to join. People who already joined keep their access."
+        confirmLabel="Revoke"
+        destructive
+        onClose={() => setShowRevokeConfirm(false)}
+        onConfirm={props.onRevoke}
+      />
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+  },
+  info: {
+    flex: 1,
+    paddingRight: 12,
+  },
+  expiry: {
+    fontSize: 14.5,
+  },
+  created: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  revokeButton: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  revokeLabel: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+})

--- a/frontend/components/ShoppingListEntry.tsx
+++ b/frontend/components/ShoppingListEntry.tsx
@@ -25,6 +25,7 @@ export type ShoppingListEntryProps = {
   onToggleSync?: (enabled: boolean) => void
   syncToggleDisabled?: boolean
   onResync?: () => void
+  onShare?: () => void
 }
 
 export function ShoppingListEntry(props: ShoppingListEntryProps) {
@@ -112,9 +113,17 @@ export function ShoppingListEntry(props: ShoppingListEntryProps) {
           // Only meaningful once sync is actually on for this list and sync
           // interactions aren't disabled (e.g. signed out) - otherwise
           // there's nothing to re-derive from the server, or no valid
-          // session to do it with.
+          // session to do it with. Inviting has the same precondition for a
+          // sharper reason: only a list the server holds a log for can be
+          // shared at all (see frontend/docs/sync-sharing-target.md 4.2),
+          // and the server only learns of one through a push.
           ...(props.syncEnabled && !props.syncToggleDisabled
             ? [
+                {
+                  label: "Invite people",
+                  testID: `shopping-list-context-share-${props.id}`,
+                  onPress: () => props.onShare?.(),
+                },
                 {
                   label: "Re-sync from server",
                   testID: `shopping-list-context-resync-${props.id}`,

--- a/frontend/docs/sync-sharing-target.md
+++ b/frontend/docs/sync-sharing-target.md
@@ -168,12 +168,20 @@ mit dem Cascade aus 4.4 passiert: `DELETE FROM synced_lists` reißt Mitgliedscha
 mit, und Zugriffsdaten sind das Einzige in diesem System, was sich *nicht* aus dem Log rekonstruieren
 lässt.
 
-**Frontend-Stand:** Kein Teil dieses Abschnitts hat eine Entsprechung im Frontend. `grep -ri invite`
-über `frontend/{api,app,components,database,types}` findet keinen Treffer — es gibt weder eine
-Einladungs-UI (erzeugen/auflisten/widerrufen) noch einen Redeem-Handler für den Deep-Link aus 4.3,
-noch eine Owner-/Member-Unterscheidung in der Listenansicht, noch „Verlassen" oder „Entsyncen". Die
-✅-Markierungen oben gelten ausschließlich für das Backend; produktseitig ist Teilen für Nutzer noch
-nicht erreichbar.
+**Frontend-Stand:** Gebaut ist genau die **Owner-Seite von 4.3**:
+`app/(home)/share_shopping_list.tsx` — erreichbar über „Invite people" im Kontextmenü einer Liste,
+und zwar nur solange dieses Gerät sie synct und ein Login besteht (beides Vorbedingung dafür, dass
+der Server überhaupt eine Registry-Zeile hat, siehe 4.2) — erzeugt, listet und widerruft
+Einladungen über `api/sharing/sharing-client.ts`. Der Deep-Link wird clientseitig aus dem Token
+gebaut (`api/sharing/invite-link.ts`, `<scheme>://invite?token=…`), passend zu „das Backend kennt
+keine Frontend-Routen".
+
+Weiterhin offen: **kein Redeem-Handler** — der Link wird von nichts entgegengenommen, `+native-intent.ts`
+kennt ihn nicht, ein Eingeladener kann also noch nicht beitreten. Ebenso fehlen eine Mitgliederliste
+(es gibt keinen Endpunkt dafür), die Owner-/Member-Unterscheidung in der Listenansicht, „Verlassen"
+und „Entsyncen". Solange `GET .../membership` offen ist, kann der Client seine eigene Rolle nicht
+erfragen: ein Member erfährt erst aus dem 403 der Einladungsroute, dass die Liste ihm nicht gehört —
+die Einladungs-UI zeigt das als Fehlermeldung, statt den Einstieg zu verstecken.
 
 ## 6. Invarianten
 

--- a/frontend/hooks/useListInvites.ts
+++ b/frontend/hooks/useListInvites.ts
@@ -1,0 +1,166 @@
+import React from "react"
+
+import { createLogger } from "@/api/common/logger"
+import { SharingError } from "@/api/common/error-types"
+import {
+  CreatedInvite,
+  InviteTTL,
+  ListInvite,
+  sharingClient,
+} from "@/api/sharing/sharing-client"
+
+const logger = createLogger("useListInvites")
+
+/**
+ * Turns a failure into something the owner can act on. Every branch names
+ * the next step, because each of these is recoverable: sign in again, put
+ * the list on the server once, or stop trying (it isn't yours).
+ */
+export function describeSharingError(error: SharingError): string {
+  switch (error.kind) {
+    case "unauthenticated":
+      return "Your session expired. Sign in again to manage invites."
+    case "notOwner":
+      return "Only the owner of this list can invite people to it."
+    case "listUnknown":
+      return (
+        "The server does not know this list yet. It is uploaded the first " +
+        "time this device syncs it - try again in a moment."
+      )
+    case "inviteGone":
+      return "That invite link was already revoked or has expired."
+    case "invalid":
+      return "The server rejected the request."
+    case "network":
+      return "Could not reach the server. Check your connection and retry."
+    case "server":
+      return "The server ran into a problem. Please try again."
+  }
+}
+
+/**
+ * State for the invite screen of one list: the active links, creating a new
+ * one, and revoking an existing one.
+ *
+ * `enabled` gates every request. The screen still has to call this hook
+ * unconditionally (rules of hooks), but there is no point asking the backend
+ * about invites while signed out or without a backend URL - the answer would
+ * be a 401 dressed up as an error message.
+ */
+export function useListInvites(listId: string, enabled: boolean) {
+  const [invites, setInvites] = React.useState<ListInvite[]>([])
+  const [isLoading, setIsLoading] = React.useState(enabled)
+  const [error, setError] = React.useState<SharingError | null>(null)
+  const [isCreating, setIsCreating] = React.useState(false)
+  const [revokingInviteId, setRevokingInviteId] = React.useState<string | null>(
+    null
+  )
+  /**
+   * When the invites on screen were fetched. Rows measure "expires in ..."
+   * against this instead of reading a clock while rendering, so every row
+   * of one load agrees on the current time and re-rendering can't shift it.
+   * 0 until the first load - by which point there are no rows to date.
+   */
+  const [loadedAt, setLoadedAt] = React.useState(0)
+  /**
+   * The link that was just created, kept in state because it can never be
+   * fetched again: only the token's hash is stored server-side. Cleared by
+   * dismissNewInvite once the owner has shared or copied it.
+   */
+  const [newInvite, setNewInvite] = React.useState<CreatedInvite | null>(null)
+
+  const refresh = React.useCallback(
+    async (options?: { background?: boolean }) => {
+      if (!enabled || !listId) {
+        setIsLoading(false)
+        return
+      }
+      // A reload that follows a create or a revoke must not blank the list
+      // already on screen: the spinner would replace the very row whose
+      // revoke is still in flight.
+      if (!options?.background) {
+        setIsLoading(true)
+      }
+      const result = await sharingClient.getInvites(listId)
+      if (result.success) {
+        setInvites(result.getValue()!)
+        setLoadedAt(Date.now())
+        setError(null)
+      } else {
+        const sharingError = result.getError()
+        logger.warn("Could not load invite links", sharingError)
+        setError(sharingError)
+      }
+      setIsLoading(false)
+    },
+    [enabled, listId]
+  )
+
+  React.useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const createInvite = React.useCallback(
+    async (ttl: InviteTTL) => {
+      if (!enabled || !listId) return
+      setIsCreating(true)
+      const result = await sharingClient.createInvite(listId, ttl)
+      if (result.success) {
+        setNewInvite(result.getValue())
+        setError(null)
+        // The new link belongs in the active list too - reload rather than
+        // splicing it in, so the screen keeps showing exactly what the
+        // server considers active.
+        await refresh({ background: true })
+      } else {
+        const sharingError = result.getError()
+        logger.warn("Could not create an invite link", sharingError)
+        setError(sharingError)
+      }
+      setIsCreating(false)
+    },
+    [enabled, listId, refresh]
+  )
+
+  const revokeInvite = React.useCallback(
+    async (inviteId: string) => {
+      if (!enabled) return
+      setRevokingInviteId(inviteId)
+      const result = await sharingClient.revokeInvite(inviteId)
+      // Reload either way: a revoke that failed because the invite was
+      // already gone leaves the list stale in exactly the same way a
+      // successful one does.
+      await refresh({ background: true })
+      // Reported *after* the reload, whose own success clears the error -
+      // otherwise a rejected revoke (403, 500) would leave the row in place
+      // and say nothing about why.
+      if (result.success) {
+        setError(null)
+      } else {
+        const sharingError = result.getError()
+        logger.warn("Could not revoke the invite link", sharingError)
+        setError(sharingError)
+      }
+      setRevokingInviteId(null)
+    },
+    [enabled, refresh]
+  )
+
+  const dismissNewInvite = React.useCallback(() => setNewInvite(null), [])
+
+  return {
+    invites,
+    /** Reference time for the loaded invites - see loadedAt. */
+    now: loadedAt,
+    isLoading,
+    error,
+    errorMessage: error ? describeSharingError(error) : null,
+    refresh,
+    createInvite,
+    isCreating,
+    newInvite,
+    dismissNewInvite,
+    revokeInvite,
+    revokingInviteId,
+  }
+}

--- a/frontend/utils/__tests__/inviteFormatting.test.ts
+++ b/frontend/utils/__tests__/inviteFormatting.test.ts
@@ -1,0 +1,72 @@
+import {
+  formatInviteCreatedAt,
+  formatInviteExpiry,
+  formatInviteTtl,
+} from "../inviteFormatting"
+
+const NOW = Date.parse("2026-08-20T12:00:00Z")
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+describe("formatInviteTtl", () => {
+  it("labels every preset the backend accepts", () => {
+    expect(formatInviteTtl("1h")).toBe("1 hour")
+    expect(formatInviteTtl("24h")).toBe("24 hours")
+    expect(formatInviteTtl("7d")).toBe("7 days")
+    expect(formatInviteTtl("30d")).toBe("30 days")
+  })
+})
+
+describe("formatInviteExpiry", () => {
+  it("counts down in the largest unit that still fits", () => {
+    expect(formatInviteExpiry(NOW + 30 * MINUTE, NOW)).toBe(
+      "Expires in 30 minutes"
+    )
+    expect(formatInviteExpiry(NOW + 5 * HOUR, NOW)).toBe("Expires in 5 hours")
+    expect(formatInviteExpiry(NOW + 7 * DAY, NOW)).toBe("Expires in 7 days")
+  })
+
+  it("uses the singular for exactly one unit", () => {
+    expect(formatInviteExpiry(NOW + MINUTE, NOW)).toBe("Expires in 1 minute")
+    expect(formatInviteExpiry(NOW + HOUR, NOW)).toBe("Expires in 1 hour")
+    expect(formatInviteExpiry(NOW + DAY, NOW)).toBe("Expires in 1 day")
+  })
+
+  // Rounding down never overstates how long a link is still good for.
+  it("rounds down rather than up", () => {
+    expect(formatInviteExpiry(NOW + 47 * HOUR, NOW)).toBe("Expires in 1 day")
+    expect(formatInviteExpiry(NOW + 119 * MINUTE, NOW)).toBe(
+      "Expires in 1 hour"
+    )
+  })
+
+  it("reports anything under a minute without a number", () => {
+    expect(formatInviteExpiry(NOW + 30_000, NOW)).toBe(
+      "Expires in less than a minute"
+    )
+  })
+
+  it("reports a past or current expiry as expired", () => {
+    expect(formatInviteExpiry(NOW, NOW)).toBe("Expired")
+    expect(formatInviteExpiry(NOW - HOUR, NOW)).toBe("Expired")
+  })
+
+  it("says so when the server sent no readable expiry", () => {
+    expect(formatInviteExpiry(null, NOW)).toBe("Expiry unknown")
+  })
+})
+
+describe("formatInviteCreatedAt", () => {
+  it("renders the creation date", () => {
+    const created = Date.parse("2026-08-20T10:00:00Z")
+
+    expect(formatInviteCreatedAt(created)).toBe(
+      `Created ${new Date(created).toLocaleDateString()}`
+    )
+  })
+
+  it("falls back to a placeholder without a date", () => {
+    expect(formatInviteCreatedAt(null)).toBe("Created at an unknown time")
+  })
+})

--- a/frontend/utils/inviteFormatting.ts
+++ b/frontend/utils/inviteFormatting.ts
@@ -1,0 +1,67 @@
+import { InviteTTL } from "@/api/sharing/sharing-client"
+
+/** Human-readable label for a validity preset the backend accepts. */
+export function formatInviteTtl(ttl: InviteTTL): string {
+  switch (ttl) {
+    case "1h":
+      return "1 hour"
+    case "24h":
+      return "24 hours"
+    case "7d":
+      return "7 days"
+    case "30d":
+      return "30 days"
+  }
+}
+
+function plural(value: number, unit: string): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`
+}
+
+/**
+ * How long an invite is still good for, relative to `now`.
+ *
+ * `now` is a parameter rather than a call to Date.now() so the same input
+ * always renders the same string - the screen passes the timestamp it
+ * rendered with, and a test doesn't have to freeze the clock.
+ *
+ * Rounds down, so an invite with 47 hours left reads "1 day": the exact
+ * expiry is on the same row, and overstating remaining validity is the more
+ * annoying of the two errors.
+ */
+export function formatInviteExpiry(
+  expiresAt: number | null,
+  now: number
+): string {
+  if (expiresAt === null) {
+    return "Expiry unknown"
+  }
+
+  const remainingMs = expiresAt - now
+  if (remainingMs <= 0) {
+    return "Expired"
+  }
+
+  const minutes = Math.floor(remainingMs / 60_000)
+  if (minutes < 1) {
+    return "Expires in less than a minute"
+  }
+  if (minutes < 60) {
+    return `Expires in ${plural(minutes, "minute")}`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `Expires in ${plural(hours, "hour")}`
+  }
+
+  return `Expires in ${plural(Math.floor(hours / 24), "day")}`
+}
+
+/** Absolute creation date, or a placeholder when the server sent none. */
+export function formatInviteCreatedAt(createdAt: number | null): string {
+  if (createdAt === null) {
+    return "Created at an unknown time"
+  }
+  return `Created ${new Date(createdAt).toLocaleDateString()}`
+}


### PR DESCRIPTION
## Summary

- Adds the **owner side** of list sharing to the frontend (backend invite endpoints already existed but were unreachable from the app). A synced list gets an "Invite people" entry in its context menu, guarded by the same precondition as re-sync (this device syncs the list and is signed in).
- New screen `app/(home)/share_shopping_list.tsx` lists a list's active invite links, creates a new one with a server-side TTL preset (1h / 24h / 7d / 30d), revokes existing ones, and hands a fresh link to the system share sheet.
- The invite deep link (`<app scheme>://invite?token=…`) is assembled client-side (`api/sharing/invite-link.ts`) since the backend has no notion of frontend routes; only the token's hash is stored server-side, so the plaintext is shown exactly once, in the create response.
- Ownership is enforced server-side and there's no membership endpoint to check in advance, so a non-owner learns it from a 403 rendered as an explanation rather than a hidden button.
- `frontend/docs/sync-sharing-target.md` §5 and `frontend/README.md` updated to describe what's now implemented.

## Known gap (intentionally out of scope here)

**Redeeming is not implemented.** Nothing in the app handles the invite deep link yet, so an invited person cannot actually join through it, and the "people with access" section is a placeholder (listing members needs a `GET .../membership` endpoint that doesn't exist yet). This is a deliberate scope cut for this PR — the redeem flow is planned as a separate follow-up.

## Test plan

- [x] `pnpm lint` (eslint + tsc --noEmit) — clean
- [x] `pnpm test` — 50 suites / 528 tests passed, including the new `sharing-client.test.ts`, `invite-link.test.ts`, `inviteFormatting.test.ts`, and `share_shopping_list-test.tsx`
- [x] Manual verification in a running app/emulator — not done in this session (no device/emulator available here)