### PR TITLE
feat(frontend): let invited people join a shared list

### DIFF
--- a/TODO_UNIVERSAL_LINKS_PROMPT.md
+++ b/TODO_UNIVERSAL_LINKS_PROMPT.md
@@ -1,0 +1,35 @@
+# Prompt: Universal Links / App Links for invite redeem
+
+Paste this as a task for an agent with backend/infra access (it needs to host files on a domain and likely touch signing/deploy config, which is out of scope for a frontend-only session).
+
+---
+
+## Context
+
+This is a monorepo shopping-list app (Expo/React Native frontend in `frontend/`, Go backend in `backend/`). Owners of a synced list can generate invite links (`frontend/app/(home)/share_shopping_list.tsx` → `frontend/api/sharing/invite-link.ts`'s `buildInviteLink()`). Redeeming now works in the app (`frontend/app/(home)/redeem_invite.tsx`, added in this session), but **only via manually pasting the link or token** — there is a "Join a shared list" entry point on the home screen (`frontend/app/(home)/index.tsx`) that opens a paste field. The backend endpoint is already implemented: `POST /api/v1/invites/redeem`.
+
+**The actual goal that's still open:** tapping a shared invite link (in a messaging app, email, or a mobile browser) should open the app directly, ideally straight to the redeem screen with the token pre-filled. Today it does nothing, verified by testing: `buildInviteLink()` produces a **custom-scheme** link (`de.lightdevsolutions.sholist://invite?token=...` in prod, `.dev` suffix in dev builds), and mobile browsers don't offer to open arbitrary custom-scheme URIs from a tapped link.
+
+## Why this wasn't just wired up in the frontend session that found this
+
+A custom URL scheme is **not domain-verified** — any other app installed on the device can register an intent-filter for the same scheme and win the OS's resolution, or at minimum trigger a chooser. That's an accepted risk for this app's *existing* use of the custom scheme (the OIDC login redirect, `frontend/api/auth/redirect-uri.ts`), but only because RFC 8252 (cited in `app.config.js`'s scheme comment) considers it safe specifically thanks to PKCE — an intercepted authorization code is useless without the code verifier that never left the device. **The invite token has no equivalent protection**: it's a bare bearer credential, and whoever redeems it joins the list. Auto-opening the app from a tapped custom-scheme link would mean trusting the OS to hand that token to the right app, which isn't guaranteed. So: no `+native-intent.ts` rewriting, no route auto-matched against the custom-scheme `invite` path was added — deliberately deferred to here, where it can be done with actual domain verification.
+
+## What "verified" means and what to build
+
+Real Universal Links (iOS) / App Links (Android) are what's needed — `https://` links backed by files the OS fetches directly from the domain to confirm this exact app is allowed to handle that domain's paths, which is exactly the guarantee a custom scheme can't give:
+
+1. **Pick a domain.** Candidate: `api.shopping-list.ops.light-dev-solutions.de` (already the backend's domain, per `frontend/.env.production`), or a new subdomain if serving `.well-known` files from the API host is awkward. This is a real decision with infra implications — confirm it with the user rather than assuming.
+2. **Host, over HTTPS, from that domain:**
+   - `/.well-known/apple-app-site-association` — no file extension, served as `application/json` (some CDNs need an explicit override for this). Needs the Apple Developer Team ID and both bundle identifiers (`de.lightdevsolutions.sholist` prod, `de.lightdevsolutions.sholist.dev` dev).
+   - `/.well-known/assetlinks.json` — needs the Android package names (same two ids) and the **SHA-256 signing certificate fingerprints** for every keystore that can produce an installed build: the release keystore, and whatever EAS/Expo uses for dev/internal builds. Get these via `keytool -list -v` or `eas credentials`.
+3. **Frontend changes once the domain and files are live** (do these together with the hosting, not before — an unverified `associatedDomains`/`intentFilters` entry just breaks the fallback without adding anything):
+   - `frontend/app.config.js`: add `ios.associatedDomains: ["applinks:<domain>"]` and an `android.intentFilters` entry for `https://<domain>/invite` with `autoVerify: true`.
+   - `frontend/api/sharing/invite-link.ts`: change `buildInviteLink()` to emit `https://<domain>/${INVITE_PATH}?${INVITE_TOKEN_PARAM}=<token>` instead of the custom-scheme URL. Leave `INVITE_PATH`/`INVITE_TOKEN_PARAM` as-is — `extractInviteToken()` (same file) already parses either form for the manual-paste fallback, so it keeps working either way.
+   - Add the actual route that receives the opened link. Expo Router matches a path to a file automatically (that's why `+native-intent.ts` only special-cases the OIDC path today, to *stop* auto-navigation, not enable it) — a root-level `app/invite.tsx` matching `/invite` is probably enough; have it read the `token` query param and either redirect into `redeem_invite.tsx`'s flow or reuse `useRedeemInvite` (`frontend/hooks/useRedeemInvite.ts`) directly. Keep the existing confirm-before-joining behavior (`redeem_invite.tsx`'s "Join list" button) rather than auto-redeeming on open — a link opened by mistake shouldn't silently add someone to a list.
+4. **Verify for real**, not just in a simulator:
+   - Android: install the built app, then `adb shell pm get-app-links de.lightdevsolutions.sholist` (or `.dev`) to confirm verification succeeded, then tap a real link in Chrome/a messaging app.
+   - iOS: Universal Links need a physical device (the simulator doesn't do AASA verification reliably); tap a real link in Safari/Messages.
+
+## Explicitly out of scope for you to re-derive
+
+The redeem screen, its API client method, and the sync-after-join flow (enable `list_sync_settings`, then `SyncEngine.pullList`) already exist and are tested (`frontend/app/(home)/redeem_invite.tsx`, `frontend/hooks/useRedeemInvite.ts`, `frontend/api/sharing/sharing-client.ts`'s `redeemInvite`). You don't need to touch or re-review that logic — this task is purely about the transport (verified https links) and wiring the OS-level open into the app, not about how redeeming itself works.

--- a/frontend/api/sharing/__tests__/invite-link.test.ts
+++ b/frontend/api/sharing/__tests__/invite-link.test.ts
@@ -1,4 +1,8 @@
-import { buildInviteLink, INVITE_PATH } from "../invite-link"
+import {
+  buildInviteLink,
+  extractInviteToken,
+  INVITE_PATH,
+} from "../invite-link"
 import { getRedirectScheme } from "@/api/auth/redirect-uri"
 
 jest.mock("@/api/auth/redirect-uri", () => ({
@@ -41,5 +45,39 @@ describe("buildInviteLink", () => {
     mockGetRedirectScheme.mockReturnValue(null)
 
     expect(buildInviteLink("token-1")).toBeNull()
+  })
+})
+
+describe("extractInviteToken", () => {
+  it("pulls the token out of a full invite link", () => {
+    expect(
+      extractInviteToken(
+        `de.lightdevsolutions.sholist.dev://${INVITE_PATH}?token=abc123`
+      )
+    ).toBe("abc123")
+  })
+
+  it("decodes a url-escaped token", () => {
+    expect(
+      extractInviteToken(`app.test://${INVITE_PATH}?token=a%2Bb%2Fc%3D`)
+    ).toBe("a+b/c=")
+  })
+
+  it("stops at the next query param", () => {
+    expect(
+      extractInviteToken(`app.test://${INVITE_PATH}?token=abc123&other=xyz`)
+    ).toBe("abc123")
+  })
+
+  it("treats input without a token param as a raw token", () => {
+    expect(extractInviteToken("abc123")).toBe("abc123")
+  })
+
+  it("trims surrounding whitespace", () => {
+    expect(extractInviteToken("  abc123  ")).toBe("abc123")
+  })
+
+  it("returns null for empty input", () => {
+    expect(extractInviteToken("   ")).toBeNull()
   })
 })

--- a/frontend/api/sharing/__tests__/sharing-client.test.ts
+++ b/frontend/api/sharing/__tests__/sharing-client.test.ts
@@ -220,4 +220,74 @@ describe("SharingClient", () => {
       expect(result.getError().kind).toBe("inviteGone")
     })
   })
+
+  describe("redeemInvite", () => {
+    it("posts the token and returns the joined list", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse(200, {
+          list_id: "list-1",
+          role: "member",
+          already_member: false,
+        })
+      )
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.redeemInvite("plaintext-token")
+
+      expect(result.success).toBe(true)
+      expect(result.getValue()).toEqual({
+        listId: "list-1",
+        role: "member",
+        alreadyMember: false,
+      })
+
+      const [url, options] = fetchMock.mock.calls[0]
+      expect(url).toContain("/api/v1/invites/redeem")
+      expect(options.method).toBe("POST")
+      expect(JSON.parse(options.body)).toEqual({ token: "plaintext-token" })
+    })
+
+    it("reports an idempotent retry as already a member", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse(200, {
+          list_id: "list-1",
+          role: "member",
+          already_member: true,
+        })
+      )
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.redeemInvite("plaintext-token")
+
+      expect(result.getValue()?.alreadyMember).toBe(true)
+    })
+
+    it("fails when the response carries no list id", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(200, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.redeemInvite("plaintext-token")
+
+      expect(result.success).toBe(false)
+      expect(result.getError().kind).toBe("server")
+    })
+
+    it("maps an unknown/expired token to inviteGone", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(410, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.redeemInvite("plaintext-token")
+
+      expect(result.getError().kind).toBe("inviteGone")
+    })
+
+    it("maps a malformed token to invalid", async () => {
+      const fetchMock = jest.fn().mockResolvedValue(jsonResponse(400, {}))
+      const client = new SharingClient(fetchMock)
+
+      const result = await client.redeemInvite("not-a-real-token")
+
+      expect(result.getError().kind).toBe("invalid")
+    })
+  })
 })

--- a/frontend/api/sharing/config.ts
+++ b/frontend/api/sharing/config.ts
@@ -24,4 +24,8 @@ export const sharingConfig = {
     const base = syncConfig.apiBaseUrl
     return `${base}/api/v1/invites/${encodeURIComponent(inviteId)}`
   },
+  redeemInviteUrl(): string {
+    const base = syncConfig.apiBaseUrl
+    return `${base}/api/v1/invites/redeem`
+  },
 }

--- a/frontend/api/sharing/invite-link.ts
+++ b/frontend/api/sharing/invite-link.ts
@@ -1,11 +1,13 @@
 import { getRedirectScheme } from "@/api/auth/redirect-uri"
 
 /**
- * The deep-link path an invite points at. Redeeming is not implemented yet -
- * nothing in the app navigates here (see the note in
- * frontend/docs/sync-sharing-target.md §5) - but the link the owner shares
- * has to be built now, and its shape is what a future redeem handler will
- * have to match.
+ * The deep-link path an invite points at. Nothing in the app auto-opens on
+ * this path yet: the link uses the app's custom scheme, which isn't
+ * domain-verified, so any tap-to-open handling here would trust whichever
+ * app the OS resolves the scheme to - see redeem_invite.tsx and
+ * TODO_UNIVERSAL_LINKS_PROMPT.md. Redeeming instead goes through a manual
+ * paste entry point (`extractInviteToken` below) until real https
+ * Universal/App Links exist.
  */
 export const INVITE_PATH = "invite"
 
@@ -33,4 +35,33 @@ export function buildInviteLink(token: string): string | null {
   }
   const encodedToken = encodeURIComponent(token)
   return `${scheme}://${INVITE_PATH}?${INVITE_TOKEN_PARAM}=${encodedToken}`
+}
+
+/**
+ * Pulls a redeemable token out of whatever a person pasted: a full invite
+ * link, or the raw token by itself. `URL` can choke on a custom-scheme
+ * value depending on the runtime, so the query string is parsed by hand
+ * instead of relying on it - this only ever runs on manually pasted text
+ * (see redeem_invite.tsx), never on an incoming system deep link.
+ */
+export function extractInviteToken(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return null
+  }
+  const marker = `${INVITE_TOKEN_PARAM}=`
+  const markerIndex = trimmed.indexOf(marker)
+  if (markerIndex === -1) {
+    // No query param found - treat the whole input as a raw token.
+    return trimmed
+  }
+  const afterMarker = trimmed.slice(markerIndex + marker.length)
+  const nextParam = afterMarker.indexOf("&")
+  const rawToken =
+    nextParam === -1 ? afterMarker : afterMarker.slice(0, nextParam)
+  try {
+    return decodeURIComponent(rawToken)
+  } catch {
+    return rawToken
+  }
 }

--- a/frontend/api/sharing/sharing-client.ts
+++ b/frontend/api/sharing/sharing-client.ts
@@ -40,6 +40,18 @@ export type CreatedInvite = {
   expiresAt: number | null
 }
 
+/**
+ * The redeem response - deliberately name-less (sync-sharing-target.md §4.3):
+ * the server has nothing else to say about a list it never parses. The
+ * list's name arrives later, from the first `todo_list.created` event a
+ * post-redeem pull applies.
+ */
+export type RedeemedInvite = {
+  listId: string
+  role: string
+  alreadyMember: boolean
+}
+
 export type FetchLike = typeof fetch
 
 type WireInvite = {
@@ -52,6 +64,12 @@ type WireInvite = {
 type WireCreatedInvite = WireInvite & {
   list_id?: unknown
   token?: unknown
+}
+
+type WireRedeemedInvite = {
+  list_id?: unknown
+  role?: unknown
+  already_member?: unknown
 }
 
 /**
@@ -71,14 +89,14 @@ function parseTimestamp(value: unknown): number | null {
 }
 
 /**
- * 404 means two different things depending on what was addressed, and the
- * two have opposite remedies: a list the server doesn't know yet needs one
- * successful push, while an invite it doesn't know is simply gone. `subject`
- * is which of the two the request was about.
+ * 404 means different things depending on what was addressed - a list the
+ * server doesn't know yet needs one successful push, while an invite or
+ * redeem token it doesn't know is simply gone/invalid. `subject` is which of
+ * the three the request was about.
  */
 function errorForStatus(
   status: number,
-  subject: "list" | "invite"
+  subject: "list" | "invite" | "redeem"
 ): SharingError {
   const map: Record<number, [string, SharingErrorKind]> = {
     400: ["The server rejected the request", "invalid"],
@@ -101,7 +119,7 @@ type RequestSpec = {
   url: string
   method: "GET" | "POST" | "DELETE"
   body?: string
-  subject: "list" | "invite"
+  subject: "list" | "invite" | "redeem"
   networkErrorMessage: string
 }
 
@@ -314,6 +332,50 @@ export class SharingClient {
       return Result.fail(responseResult.getError())
     }
     return Result.ok<void, SharingError>(null)
+  }
+
+  /**
+   * Joins the list a token points at. Idempotent server-side: an already-a-
+   * member caller gets `already_member: true` back instead of an error, so a
+   * retry of a lost response is always safe (sync-design-decisions.md).
+   */
+  async redeemInvite(
+    token: string
+  ): Promise<Result<RedeemedInvite, SharingError>> {
+    const responseResult = await this.request({
+      url: sharingConfig.redeemInviteUrl(),
+      method: "POST",
+      body: JSON.stringify({ token }),
+      subject: "redeem",
+      networkErrorMessage: "Network error while joining the list",
+    })
+    if (!responseResult.success) {
+      return Result.fail(responseResult.getError())
+    }
+
+    const bodyResult = await this.parseJson(
+      responseResult.getValue()!,
+      "redeem"
+    )
+    if (!bodyResult.success) {
+      return Result.fail(bodyResult.getError())
+    }
+
+    const body = bodyResult.getValue() as WireRedeemedInvite
+    if (typeof body?.list_id !== "string") {
+      return Result.fail(
+        new SharingError(
+          "The server did not say which list this joins",
+          "server"
+        )
+      )
+    }
+
+    return Result.ok({
+      listId: body.list_id,
+      role: typeof body.role === "string" ? body.role : "member",
+      alreadyMember: body.already_member === true,
+    })
   }
 }
 

--- a/frontend/app/(home)/__tests__/redeem_invite-test.tsx
+++ b/frontend/app/(home)/__tests__/redeem_invite-test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { renderRouter } from "expo-router/testing-library"
+
+import RedeemInvite from "../redeem_invite"
+import { Result } from "@/api/common/result"
+import { SharingError } from "@/api/common/error-types"
+import { useAuth } from "@/api/auth/AuthProvider"
+import { sharingClient } from "@/api/sharing/sharing-client"
+import { useSyncEngine } from "@/api/sync/SyncProvider"
+
+jest.mock("@/api/auth/AuthProvider")
+
+// The client itself is covered by sharing-client.test.ts; here it stands in
+// for the backend so the screen's own behaviour is what's under test.
+jest.mock("@/api/sharing/sharing-client", () => {
+  const actual = jest.requireActual("@/api/sharing/sharing-client")
+  return {
+    ...actual,
+    sharingClient: {
+      redeemInvite: jest.fn(),
+    },
+  }
+})
+
+jest.mock("@/api/sync/SyncProvider", () => ({
+  useSyncEngine: jest.fn(),
+}))
+
+jest.mock("@/database/list-sync-settings-repository", () => ({
+  ListSyncSettingsRepository: jest.fn().mockImplementation(() => ({
+    setEnabled: jest.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+jest.mock("@/database/database", () => ({
+  getDatabase: jest.fn(),
+}))
+
+const mockedUseAuth = useAuth as jest.Mock
+const mockRedeemInvite = sharingClient.redeemInvite as jest.Mock
+const mockedUseSyncEngine = useSyncEngine as jest.Mock
+
+function mockAuth(status: "loading" | "signedIn" | "signedOut") {
+  mockedUseAuth.mockReturnValue({
+    status,
+    user: null,
+    error: null,
+    busy: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+  })
+}
+
+function renderRedeemScreen() {
+  return renderRouter(
+    { redeem_invite: RedeemInvite },
+    { initialUrl: "/redeem_invite" }
+  )
+}
+
+describe("RedeemInvite", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAuth("signedIn")
+    mockedUseSyncEngine.mockReturnValue({
+      pullList: jest.fn().mockResolvedValue(undefined),
+    })
+    mockRedeemInvite.mockResolvedValue(
+      Result.ok({ listId: "list-1", role: "member", alreadyMember: false })
+    )
+  })
+
+  it("redeems the pasted token and shows success", async () => {
+    renderRedeemScreen()
+
+    fireEvent.changeText(
+      screen.getByTestId("redeem-token-input"),
+      "app.test://invite?token=plaintext-token"
+    )
+    fireEvent.press(screen.getByTestId("redeem-join"))
+
+    await waitFor(() => {
+      expect(mockRedeemInvite).toHaveBeenCalledWith("plaintext-token")
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("redeem-go-to-list")).toBeTruthy()
+    })
+  })
+
+  it("treats pasted input without a token param as a raw token", async () => {
+    renderRedeemScreen()
+
+    fireEvent.changeText(screen.getByTestId("redeem-token-input"), "raw-code")
+    fireEvent.press(screen.getByTestId("redeem-join"))
+
+    await waitFor(() => {
+      expect(mockRedeemInvite).toHaveBeenCalledWith("raw-code")
+    })
+  })
+
+  it("shows a distinct message when already a member", async () => {
+    mockRedeemInvite.mockResolvedValue(
+      Result.ok({ listId: "list-1", role: "member", alreadyMember: true })
+    )
+
+    renderRedeemScreen()
+
+    fireEvent.changeText(screen.getByTestId("redeem-token-input"), "a-token")
+    fireEvent.press(screen.getByTestId("redeem-join"))
+
+    await waitFor(() => {
+      expect(screen.getByText(/already a member/i)).toBeTruthy()
+    })
+  })
+
+  it("shows an error message for an invalid or expired invite", async () => {
+    mockRedeemInvite.mockResolvedValue(
+      Result.fail(new SharingError("nope", "inviteGone"))
+    )
+
+    renderRedeemScreen()
+
+    fireEvent.changeText(screen.getByTestId("redeem-token-input"), "a-token")
+    fireEvent.press(screen.getByTestId("redeem-join"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("redeem-error")).toHaveTextContent(
+        /invalid, was revoked, or has expired/i
+      )
+    })
+  })
+
+  it("asks the user to sign in and stays off the network when signed out", async () => {
+    mockAuth("signedOut")
+
+    renderRedeemScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("redeem-unavailable")).toBeTruthy()
+    })
+    expect(mockRedeemInvite).not.toHaveBeenCalled()
+  })
+
+  it("waits for the session to be restored before judging it", async () => {
+    mockAuth("loading")
+
+    renderRedeemScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("redeem-auth-loading")).toBeTruthy()
+    })
+    expect(screen.queryByTestId("redeem-unavailable")).toBeNull()
+  })
+
+  it("disables the join button until something is entered", async () => {
+    renderRedeemScreen()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("redeem-join")).toBeTruthy()
+    })
+    fireEvent.press(screen.getByTestId("redeem-join"))
+    expect(mockRedeemInvite).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/app/(home)/_layout.tsx
+++ b/frontend/app/(home)/_layout.tsx
@@ -55,6 +55,12 @@ export default function HomeLayout() {
           headerTitle: "Invite people",
         }}
       />
+      <Stack.Screen
+        name="redeem_invite"
+        options={{
+          headerTitle: "Join list",
+        }}
+      />
     </Stack>
   )
 }

--- a/frontend/app/(home)/index.tsx
+++ b/frontend/app/(home)/index.tsx
@@ -1,7 +1,13 @@
 import { ActionButton } from "@/components/ActionButton"
 import { Palette } from "@/constants/Colors"
 import React from "react"
-import { FlatList, StyleSheet, ActivityIndicator, View } from "react-native"
+import {
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+  Pressable,
+  View,
+} from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import { router, useFocusEffect } from "expo-router"
 import { getPreference } from "@/database/preferences-repository"
@@ -153,6 +159,10 @@ export default function Index() {
     router.push("/new_shopping_list")
   }
 
+  const handleJoinSharedList = () => {
+    router.push("/redeem_invite")
+  }
+
   const renderContent = () => {
     if (isLoading || isCheckingPreference) {
       return (
@@ -194,6 +204,14 @@ export default function Index() {
   return (
     <SafeAreaView style={styles.container} edges={["bottom"]}>
       <View style={[styles.headerDivider, { backgroundColor: dividerColor }]} />
+      <Pressable
+        testID="join-shared-list-link"
+        accessibilityRole="button"
+        onPress={handleJoinSharedList}
+        style={styles.joinLinkRow}
+      >
+        <ThemedText type="link">Join a shared list</ThemedText>
+      </Pressable>
       {renderContent()}
       <ActionButton testID="add-button" symbol="+" onPress={handleAddList} />
     </SafeAreaView>
@@ -207,6 +225,10 @@ const styles = StyleSheet.create({
   headerDivider: {
     height: 1,
     width: "100%",
+  },
+  joinLinkRow: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
   },
   centered: {
     flex: 1,

--- a/frontend/app/(home)/redeem_invite.tsx
+++ b/frontend/app/(home)/redeem_invite.tsx
@@ -1,0 +1,178 @@
+import React from "react"
+import { ActivityIndicator, ScrollView, StyleSheet, View } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { router } from "expo-router"
+
+import { useAuth } from "@/api/auth/AuthProvider"
+import { isSharingConfigured } from "@/api/sharing/config"
+import { extractInviteToken } from "@/api/sharing/invite-link"
+import { useSyncEngine } from "@/api/sync/SyncProvider"
+import { PrimaryButton } from "@/components/PrimaryButton"
+import { ThemedText } from "@/components/ThemedText"
+import { ThemedTextInput } from "@/components/ThemedTextInput"
+import { useRedeemInvite } from "@/hooks/useRedeemInvite"
+import { useThemeColor } from "@/hooks/useThemeColor"
+
+/**
+ * Joins a shared list from an invite link or raw token, pasted in by hand.
+ *
+ * Reached only from the "Join a shared list" action on the home screen -
+ * not from a system deep link. The invite link uses the app's custom
+ * scheme, which isn't domain-verified, so auto-opening this screen from a
+ * tapped link would trust whichever app the OS resolves that scheme to.
+ * See the note on INVITE_PATH in api/sharing/invite-link.ts.
+ */
+export default function RedeemInvite() {
+  const { status } = useAuth()
+  const isSignedIn = status === "signedIn"
+  const configured = isSharingConfigured()
+  const engine = useSyncEngine()
+  const canRedeem = isSignedIn && configured
+
+  const [input, setInput] = React.useState("")
+  const {
+    status: redeemStatus,
+    errorMessage,
+    result,
+    redeem,
+  } = useRedeemInvite(canRedeem, engine)
+
+  const backgroundColor = useThemeColor({}, "background")
+  const textSecondaryColor = useThemeColor({}, "textSecondary")
+  const dangerColor = useThemeColor({}, "danger")
+
+  const isBusy = redeemStatus === "redeeming" || redeemStatus === "syncing"
+
+  const handleJoin = () => {
+    const token = extractInviteToken(input)
+    if (!token) return
+    redeem(token)
+  }
+
+  const handleGoToList = () => {
+    if (!result) return
+    router.replace(`/view_shopping_list?listId=${result.listId}`)
+  }
+
+  const renderUnavailable = (message: string) => (
+    <ThemedText
+      testID="redeem-unavailable"
+      style={[styles.hint, { color: textSecondaryColor }]}
+    >
+      {message}
+    </ThemedText>
+  )
+
+  const renderContent = () => {
+    if (!configured) {
+      return renderUnavailable(
+        "Joining a shared list needs a backend. Set EXPO_PUBLIC_API_URL to enable it."
+      )
+    }
+    if (status === "loading") {
+      return (
+        <ActivityIndicator
+          testID="redeem-auth-loading"
+          size="small"
+          style={styles.loader}
+        />
+      )
+    }
+    if (!isSignedIn) {
+      return renderUnavailable("Sign in to join a shared list.")
+    }
+
+    if (redeemStatus === "success" && result) {
+      return (
+        <View style={styles.section}>
+          <ThemedText type="subtitle">
+            {result.alreadyMember ? "You're already in" : "You're in!"}
+          </ThemedText>
+          <ThemedText style={[styles.hint, { color: textSecondaryColor }]}>
+            {result.alreadyMember
+              ? "You were already a member of this list."
+              : "You joined the list. It may take a moment to appear with its full contents."}
+          </ThemedText>
+          <PrimaryButton
+            testID="redeem-go-to-list"
+            label="Go to list"
+            onPress={handleGoToList}
+          />
+        </View>
+      )
+    }
+
+    return (
+      <View style={styles.section}>
+        <ThemedText type="subtitle">Join a shared list</ThemedText>
+        <ThemedText style={[styles.hint, { color: textSecondaryColor }]}>
+          Paste the invite link or code someone sent you.
+        </ThemedText>
+        <ThemedTextInput
+          testID="redeem-token-input"
+          value={input}
+          onChangeText={setInput}
+          onSubmit={handleJoin}
+          placeholder="Invite link or code"
+          autoFocus
+        />
+        <PrimaryButton
+          testID="redeem-join"
+          label="Join list"
+          loading={isBusy}
+          disabled={!input.trim()}
+          onPress={handleJoin}
+        />
+        {redeemStatus === "error" && errorMessage ? (
+          <ThemedText
+            testID="redeem-error"
+            style={[styles.error, { color: dangerColor }]}
+          >
+            {errorMessage}
+          </ThemedText>
+        ) : null}
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView
+      testID="redeem-invite-screen"
+      edges={["bottom"]}
+      style={[styles.container, { backgroundColor }]}
+    >
+      <ScrollView
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {renderContent()}
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    gap: 4,
+  },
+  section: {
+    gap: 12,
+    paddingVertical: 8,
+  },
+  hint: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  loader: {
+    alignSelf: "flex-start",
+    marginVertical: 8,
+  },
+  error: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+})

--- a/frontend/hooks/useRedeemInvite.ts
+++ b/frontend/hooks/useRedeemInvite.ts
@@ -1,0 +1,98 @@
+import React from "react"
+
+import { createLogger } from "@/api/common/logger"
+import { SharingError } from "@/api/common/error-types"
+import { RedeemedInvite, sharingClient } from "@/api/sharing/sharing-client"
+import { getDatabase } from "@/database/database"
+import { ListSyncSettingsRepository } from "@/database/list-sync-settings-repository"
+import { SyncEngine } from "@/api/sync/sync-engine"
+
+const logger = createLogger("useRedeemInvite")
+
+export type RedeemStatus =
+  "idle" | "redeeming" | "syncing" | "success" | "error"
+
+/**
+ * Turns a redeem failure into something the person tapping "Join" can act
+ * on. Unlike useListInvites' describeSharingError, there is no owner-only
+ * concept here - any signed-in caller can redeem a token.
+ */
+export function describeRedeemError(error: SharingError): string {
+  switch (error.kind) {
+    case "unauthenticated":
+      return "Your session expired. Sign in again to join this list."
+    case "inviteGone":
+      return "This invite link is invalid, was revoked, or has expired."
+    case "invalid":
+      return "That doesn't look like a valid invite link or token."
+    case "network":
+      return "Could not reach the server. Check your connection and retry."
+    case "notOwner":
+    case "listUnknown":
+    case "server":
+      return "The server ran into a problem. Please try again."
+  }
+}
+
+/**
+ * Redeems an invite token and pulls the list it points at down onto this
+ * device. The redeem response carries no list name (sync-sharing-target.md
+ * §4.3) - enabling sync and pulling is what actually creates the list
+ * locally, name included, from its event history.
+ */
+export function useRedeemInvite(enabled: boolean, engine: SyncEngine) {
+  const [status, setStatus] = React.useState<RedeemStatus>("idle")
+  const [error, setError] = React.useState<SharingError | null>(null)
+  const [result, setResult] = React.useState<RedeemedInvite | null>(null)
+
+  const redeem = React.useCallback(
+    async (token: string) => {
+      if (!enabled || !token.trim()) return
+      setStatus("redeeming")
+      setError(null)
+
+      const redeemResult = await sharingClient.redeemInvite(token.trim())
+      if (!redeemResult.success) {
+        const sharingError = redeemResult.getError()
+        logger.warn("Could not redeem the invite", sharingError)
+        setError(sharingError)
+        setStatus("error")
+        return
+      }
+
+      const redeemed = redeemResult.getValue()!
+      setStatus("syncing")
+      try {
+        await new ListSyncSettingsRepository(getDatabase()).setEnabled(
+          redeemed.listId,
+          true
+        )
+        await engine.pullList(redeemed.listId)
+      } catch (err) {
+        // Membership already exists server-side at this point - a failed
+        // local pull just means the list shows up on the next normal sync
+        // cycle rather than immediately. Not worth surfacing as an error.
+        logger.warn("Could not pull the joined list locally yet", err)
+      }
+
+      setResult(redeemed)
+      setStatus("success")
+    },
+    [enabled, engine]
+  )
+
+  const reset = React.useCallback(() => {
+    setStatus("idle")
+    setError(null)
+    setResult(null)
+  }, [])
+
+  return {
+    status,
+    error,
+    errorMessage: error ? describeRedeemError(error) : null,
+    result,
+    redeem,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a redeem screen and `SharingClient.redeemInvite()` for `POST /api/v1/invites/redeem`, reachable via a manual "Join a shared list" entry point (`app/(home)/index.tsx`) that accepts a pasted invite link or raw token.
- On success, enables local sync for the list and triggers `SyncEngine.pullList()` so it materializes locally with its real name/content (the redeem response itself carries no list name, per `sync-sharing-target.md` §4.3).
- Deliberately **not** wired to auto-open from the invite link's custom URL scheme (`de.lightdevsolutions.sholist://invite?token=...`): that transport isn't domain-verified, so another installed app could register the same scheme and hijack the token or spoof the join UI. `TODO_UNIVERSAL_LINKS_PROMPT.md` hands off the real fix (HTTPS Universal Links / App Links with domain verification) to a backend/infra agent.

## Test plan
- [x] `pnpm lint` (eslint + tsc --noEmit)
- [x] `pnpm test` — 546/546 passing, including new coverage for `redeemInvite` (sharing-client), `extractInviteToken` (invite-link), and the new `redeem_invite` screen
- [ ] Manual: create an invite link from `share_shopping_list`, paste it into the new "Join a shared list" screen on a second signed-in account, confirm the list appears locally with correct name/contents