### PR TITLE
fix(backend): group chore(deps) commits under Dependencies in changelog

### DIFF
--- a/backend/cliff.toml
+++ b/backend/cliff.toml
@@ -25,6 +25,7 @@ commit_parsers = [
   { message = "^ci", group = "CI" },
   { message = "^docs", group = "Documentation" },
   { message = "^test", group = "Testing" },
+  { message = "^chore\\(deps\\)", group = "Dependencies" },
   { message = ".*", group = "Other" },
 ]
 


### PR DESCRIPTION
## Summary
- `backend/cliff.toml`'s `commit_parsers` had no rule for `chore`, so every `chore(deps): ...` dependency-bump commit fell into the `.*` catch-all "Other" group.
- Adds a dedicated `^chore\(deps\)` rule mapping to a new "Dependencies" changelog group, ahead of the catch-all.
- Other non-conventional commits (e.g. squash-merge titles like `Feat/...`) still fall into "Other" as before — out of scope here.

## Test plan
- [ ] Next backend release build the changelog and confirm dependency-bump commits show under "Dependencies" instead of "Other"