### PR TITLE
feat(backend): graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	echomw "github.com/labstack/echo/v4/middleware"
@@ -40,7 +44,9 @@ func run(logger *slog.Logger) error {
 	}
 	port := ":8080"
 
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	pool, err := postgres2.NewConnection(ctx, dsn)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
@@ -98,11 +104,46 @@ func run(logger *slog.Logger) error {
 	rest.NewSyncPullController(e, logger, eventRepo, listAccessService, authMW)
 	rest.NewListSharingController(e, logger, listSharingService, authMW)
 
+	errCh := make(chan error, 1)
+	go func() {
+		if err := e.Start(port); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
 	logger.Info("server starting", "port", port)
-	if err := e.Start(port); err != nil {
-		return fmt.Errorf("failed to start server: %w", err)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return fmt.Errorf("failed to start server: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		logger.Info("shutdown signal received")
 	}
-	return nil
+
+	// Comfortably under Docker/Compose's default 10s SIGTERM->SIGKILL grace
+	// period.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	var shutdownErr error
+	if err := e.Shutdown(shutdownCtx); err != nil {
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("http server shutdown: %w", err))
+	}
+	// e.Shutdown does not close or wait for hijacked connections (the sync
+	// websocket), so the hub closes and waits for those separately.
+	if err := hub.Shutdown(shutdownCtx); err != nil {
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("hub shutdown: %w", err))
+	}
+	if err := <-errCh; err != nil {
+		shutdownErr = errors.Join(shutdownErr, fmt.Errorf("server error during shutdown: %w", err))
+	}
+
+	logger.Info("server stopped")
+	return shutdownErr
 }
 
 // httpErrorHandler logs errors that never went through a controller's own

--- a/backend/internal/infrastructure/realtime/hub.go
+++ b/backend/internal/infrastructure/realtime/hub.go
@@ -72,6 +72,12 @@ type Hub struct {
 	// subscribed to) - needed so cleanup/resubscribe can remove exactly
 	// this connection's entries from `subscriptions` without scanning it.
 	subscribedLists map[*connection]map[uuid.UUID]struct{}
+	// conns holds every live connection, including ones that haven't
+	// subscribed to anything yet - Shutdown needs to reach those too.
+	conns map[*connection]struct{}
+	// wg tracks running Serve goroutines so Shutdown can wait for them to
+	// actually exit, not just for their sockets to close.
+	wg sync.WaitGroup
 }
 
 func NewHub(logger *slog.Logger, access ListAccessFilter) *Hub {
@@ -80,6 +86,7 @@ func NewHub(logger *slog.Logger, access ListAccessFilter) *Hub {
 		access:          access,
 		subscriptions:   make(map[uuid.UUID]map[*connection]struct{}),
 		subscribedLists: make(map[*connection]map[uuid.UUID]struct{}),
+		conns:           make(map[*connection]struct{}),
 	}
 }
 
@@ -87,6 +94,7 @@ func (h *Hub) unregister(conn *connection) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.unsubscribeAllLocked(conn)
+	delete(h.conns, conn)
 }
 
 // subscribe replaces (not accumulates) the set of lists this connection is
@@ -173,6 +181,32 @@ func (h *Hub) PublishListEvent(listID uuid.UUID, seq int64) {
 	}
 }
 
+// Shutdown closes every live connection, which unblocks each one's blocked
+// ReadJSON in Serve and lets its deferred cleanup run, then waits for all
+// Serve goroutines to actually exit. Needed because http.Server.Shutdown
+// (which echo.Echo.Shutdown delegates to) explicitly does not close or wait
+// for hijacked connections like these on its own.
+func (h *Hub) Shutdown(ctx context.Context) error {
+	h.mu.Lock()
+	for conn := range h.conns {
+		_ = conn.ws.Close()
+	}
+	h.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Serve blocks, running the connection's read loop, until it closes. Meant
 // to be called from the HTTP handler goroutine that performed the upgrade -
 // it owns the connection for its entire lifetime, and ctx (the still-live
@@ -185,10 +219,15 @@ func (h *Hub) PublishListEvent(listID uuid.UUID, seq int64) {
 // unregister on the way out is what removes it again.
 func (h *Hub) Serve(ctx context.Context, userID string, ws *websocket.Conn) {
 	conn := newConnection(ws)
+	h.mu.Lock()
+	h.conns[conn] = struct{}{}
+	h.mu.Unlock()
+	h.wg.Add(1)
 	h.logger.Debug("connection opened", "user_id", userID)
 	defer func() {
 		h.unregister(conn)
 		_ = ws.Close()
+		h.wg.Done()
 		h.logger.Debug("connection closed", "user_id", userID)
 	}()
 

--- a/backend/internal/infrastructure/realtime/hub.go
+++ b/backend/internal/infrastructure/realtime/hub.go
@@ -201,11 +201,15 @@ func (h *Hub) Shutdown(ctx context.Context) error {
 	}
 	h.mu.Unlock()
 
-	// Closed outside the lock: ws.Close() can block on network I/O, and
-	// holding mu here would stall Serve's own unregister(), which needs it
-	// too.
+	// Closed outside the lock and concurrently: ws.Close() can block on
+	// network I/O, and holding mu here would stall Serve's own
+	// unregister(), which needs it too. One goroutine per connection so a
+	// single stuck Close() can't head-of-line block the rest, or delay
+	// reaching the select below that's meant to bound this by ctx.
 	for _, conn := range conns {
-		_ = conn.ws.Close()
+		go func() {
+			_ = conn.ws.Close()
+		}()
 	}
 
 	done := make(chan struct{})

--- a/backend/internal/infrastructure/realtime/hub.go
+++ b/backend/internal/infrastructure/realtime/hub.go
@@ -78,6 +78,12 @@ type Hub struct {
 	// wg tracks running Serve goroutines so Shutdown can wait for them to
 	// actually exit, not just for their sockets to close.
 	wg sync.WaitGroup
+	// closed is set under mu once Shutdown has taken its snapshot - a Serve
+	// that loses the race to register after that point must not join
+	// (registering, and calling wg.Add, after Shutdown has already started
+	// wg.Wait would be a WaitGroup misuse) since Shutdown will never see or
+	// close it.
+	closed bool
 }
 
 func NewHub(logger *slog.Logger, access ListAccessFilter) *Hub {
@@ -188,10 +194,19 @@ func (h *Hub) PublishListEvent(listID uuid.UUID, seq int64) {
 // for hijacked connections like these on its own.
 func (h *Hub) Shutdown(ctx context.Context) error {
 	h.mu.Lock()
+	h.closed = true
+	conns := make([]*connection, 0, len(h.conns))
 	for conn := range h.conns {
-		_ = conn.ws.Close()
+		conns = append(conns, conn)
 	}
 	h.mu.Unlock()
+
+	// Closed outside the lock: ws.Close() can block on network I/O, and
+	// holding mu here would stall Serve's own unregister(), which needs it
+	// too.
+	for _, conn := range conns {
+		_ = conn.ws.Close()
+	}
 
 	done := make(chan struct{})
 	go func() {
@@ -220,9 +235,14 @@ func (h *Hub) Shutdown(ctx context.Context) error {
 func (h *Hub) Serve(ctx context.Context, userID string, ws *websocket.Conn) {
 	conn := newConnection(ws)
 	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		_ = ws.Close()
+		return
+	}
 	h.conns[conn] = struct{}{}
-	h.mu.Unlock()
 	h.wg.Add(1)
+	h.mu.Unlock()
 	h.logger.Debug("connection opened", "user_id", userID)
 	defer func() {
 		h.unregister(conn)

--- a/backend/internal/infrastructure/realtime/hub_test.go
+++ b/backend/internal/infrastructure/realtime/hub_test.go
@@ -313,6 +313,54 @@ func TestHub_Unregister_RemovesTheConnectionsSubscriptions(t *testing.T) {
 	assert.False(t, exists, "the reverse index entry should be cleaned up too")
 }
 
+// TestHub_Shutdown_ClosesConnectionsAndWaitsForServeToReturn guards the
+// wrinkle Shutdown exists for: e.Shutdown never touches hijacked
+// connections, so without this the sync websocket's Serve goroutine (and
+// its underlying socket) would outlive process shutdown.
+func TestHub_Shutdown_ClosesConnectionsAndWaitsForServeToReturn(t *testing.T) {
+	hub := NewHub(testLogger(), newFakeAccessFilter())
+	server := startTestServer(t, hub)
+	conn := dial(t, server, "user-1")
+
+	require.NoError(t, conn.WriteJSON(map[string]any{
+		"type":     "subscribe",
+		"list_ids": []string{uuid.New().String()},
+	}))
+	require.Eventually(t, func() bool {
+		hub.mu.RLock()
+		defer hub.mu.RUnlock()
+		return len(hub.conns) == 1
+	}, time.Second, time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, hub.Shutdown(shutdownCtx))
+
+	hub.mu.RLock()
+	remaining := len(hub.conns)
+	hub.mu.RUnlock()
+	assert.Zero(t, remaining, "Shutdown should wait for Serve's cleanup to unregister the connection")
+
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	var msg map[string]any
+	assert.Error(t, conn.ReadJSON(&msg), "the server should have closed the connection")
+}
+
+// TestHub_Shutdown_ReturnsContextErrorOnTimeout guards the other half: a
+// Serve goroutine that never returns (e.g. stuck delivering to a stalled
+// peer) must not hang Shutdown forever - it should give up once ctx expires.
+func TestHub_Shutdown_ReturnsContextErrorOnTimeout(t *testing.T) {
+	hub := NewHub(testLogger(), newFakeAccessFilter())
+	hub.wg.Add(1)
+	t.Cleanup(hub.wg.Done)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := hub.Shutdown(shutdownCtx)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestHub_ParseListIDs_SkipsMalformedEntriesRatherThanFailingTheWholeSubscribe(t *testing.T) {
 	valid := uuid.New()
 

--- a/backend/internal/infrastructure/realtime/hub_test.go
+++ b/backend/internal/infrastructure/realtime/hub_test.go
@@ -361,6 +361,25 @@ func TestHub_Shutdown_ReturnsContextErrorOnTimeout(t *testing.T) {
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+// TestHub_Serve_RejectsNewConnectionsAfterShutdown guards the race a
+// reviewer flagged: registration (h.conns / h.wg.Add) and Shutdown's
+// snapshot both happen under h.mu, so a connection arriving after Shutdown's
+// snapshot must never join - if it did, Shutdown could already be past
+// wg.Wait() with nothing left to observe its wg.Add.
+func TestHub_Serve_RejectsNewConnectionsAfterShutdown(t *testing.T) {
+	hub := NewHub(testLogger(), newFakeAccessFilter())
+	server := startTestServer(t, hub)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, hub.Shutdown(shutdownCtx))
+
+	conn := dial(t, server, "user-1")
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	var msg map[string]any
+	assert.Error(t, conn.ReadJSON(&msg), "a connection established after Shutdown should be closed immediately")
+}
+
 func TestHub_ParseListIDs_SkipsMalformedEntriesRatherThanFailingTheWholeSubscribe(t *testing.T) {
 	valid := uuid.New()
 


### PR DESCRIPTION
## Summary
- `run()` now wraps its context in `signal.NotifyContext` for SIGTERM/SIGINT, starts Echo in a goroutine, and on shutdown calls `e.Shutdown(ctx)` followed by a new `Hub.Shutdown(ctx)`, all bounded by an 8s timeout (comfortably under Docker/Compose's default 10s SIGTERM→SIGKILL grace period). The existing `defer pool.Close()` now actually runs, since `run()` returns normally on shutdown instead of never returning.
- Added `Hub.Shutdown`: `e.Shutdown` explicitly does not close or wait for hijacked connections (the `/api/v1/sync/ws` websocket), so the hub now tracks every live connection and its `Serve` goroutine, force-closes them on shutdown, and waits for the goroutines to actually exit.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go mod tidy -diff` clean
- [x] `go test ./...` passes (incl. two new `Hub.Shutdown` tests: force-closes connections and waits for `Serve` to return; returns `context.DeadlineExceeded` if a `Serve` goroutine doesn't exit in time)
- [x] Manual: ran `go run ./cmd/api` against local Postgres + the hosted Keycloak, confirmed `/healthz` returns 200, sent `SIGTERM` to the running binary, and confirmed from the JSON logs it logged `shutdown signal received` then `server stopped` and exited cleanly well under the 8s budget (no forced kill needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)